### PR TITLE
Add gateway support in CloudCore and local APIs.

### DIFF
--- a/cogniac/__init__.py
+++ b/cogniac/__init__.py
@@ -76,13 +76,17 @@ common Cogniac objects such as applications, subjects, and media:
         return the currently authenticated CogniacTenant
 
 
-CogniacGateway(url_prefix, timeout=60)
+CogniacEdgeFlow(url_prefix, timeout=60)
+    An object representing an EdgeFlow in the Cogniac System.
 
-        Create a client connection to a gateway device (i.e., EdgeFlow):
+    An instance of this class optionally provides a client interface that 
+    communicates directly with a local EdgeFlow's APIs. The local EdgeFlow APIs
+    are useful for application such as uploading images to the EdgeFlow for 
+    fast processing "on the edge" without first uploading the images to
+    CloudCore.
 
-
-        url_prefix (String):          Cogniac API url prefix.
-                                      The url_prefix can alternatively be set via the COG_GW_URL_PREFIX environment variable.
+    url_prefix (String):          Cogniac API url prefix.
+                                    The url_prefix can alternatively be set via the COG_GW_URL_PREFIX environment variable.
 
 
 CogniacApplication
@@ -90,7 +94,7 @@ CogniacApplication
 
     Applications are the main locus of activity within the Cogniac System.
 
-    This classes manages applications within the Cogniac System via the
+    This class manages applications within the Cogniac System via the
     Cogniac public API application endpoints.
 
     Create a new application with
@@ -138,7 +142,7 @@ CogniacTenant
 """
 
 from cogniac import CogniacConnection
-from .gateway import CogniacGateway
+from .edgeflow import CogniacEdgeFlow
 from .app import CogniacApplication
 from .tenant import CogniacTenant
 from .subject import CogniacSubject

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -21,7 +21,7 @@ from subject import CogniacSubject
 from tenant  import CogniacTenant
 from user    import CogniacUser
 from media   import CogniacMedia
-from gateway import CogniacGateway
+from edgeflow import CogniacEdgeFlow
 
 from network_camera import CogniacNetworkCamera
 
@@ -439,21 +439,21 @@ class CogniacConnection(object):
         """
         return CogniacNetworkCamera.get(self, network_camera_id)
 
-    def get_all_gateways(self):
+    def get_all_edgeflows(self):
         """
-        return CogniacGateway for all netcams belonging to the currently authenticated tenant
+        return CogniacEdgeFlow for all netcams belonging to the currently authenticated tenant
         """
-        return CogniacGateway.get_all(self)
+        return CogniacEdgeFlow.get_all(self)
 
-    def get_gateway(self, gateway_id, url_prefix=None):
+    def get_edgeflow(self, edgeflow_id, url_prefix=None):
         """
-        return an existing CogniacGateway 
+        return an existing CogniacEdgeFlow 
 
-        gateway_id (String):  The id of the Cogniac Gateway to return
-        url_prefix (String):  The local URL prefix of a Gateway
+        edgeflow_id (String):  The id of the Cogniac EdgeFlow to return
+        url_prefix (String):  The local URL prefix of a EdgeFlow 
         """
-        return CogniacGateway.get(connection=self,
-                                  gateway_id=gateway_id,
+        return CogniacEdgeFlow.get(connection=self,
+                                  edgeflow_id=edgeflow_id,
                                   url_prefix=url_prefix)
 
 

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -21,6 +21,7 @@ from subject import CogniacSubject
 from tenant  import CogniacTenant
 from user    import CogniacUser
 from media   import CogniacMedia
+from gateway import CogniacGateway
 
 from network_camera import CogniacNetworkCamera
 
@@ -437,6 +438,23 @@ class CogniacConnection(object):
         network_camera_id (String):  The id of the Cogniac network camera to return
         """
         return CogniacNetworkCamera.get(self, network_camera_id)
+
+    def get_all_gateways(self):
+        """
+        return CogniacGateway for all netcams belonging to the currently authenticated tenant
+        """
+        return CogniacGateway.get_all(self)
+
+    def get_gateway(self, gateway_id=None, url_prefix=None):
+        """
+        return an existing CogniacGateway 
+
+        gateway_id (String):  The id of the Cogniac Gateway to return
+        url_prefix (String):  The local URL prefix of a Gateway
+        """
+        return CogniacGateway.get(self,
+                                  gateway_id=gateway_id,
+                                  url_prefix=url_prefix)
 
 
 if __name__ == "__main__":

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -441,20 +441,17 @@ class CogniacConnection(object):
 
     def get_all_edgeflows(self):
         """
-        return CogniacEdgeFlow for all netcams belonging to the currently authenticated tenant
+        return CogniacEdgeFlow for all EdgeFlows belonging to the currently authenticated tenant
         """
         return CogniacEdgeFlow.get_all(self)
 
-    def get_edgeflow(self, edgeflow_id, url_prefix=None):
+    def get_edgeflow(self, edgeflow_id):
         """
         return an existing CogniacEdgeFlow 
 
         edgeflow_id (String):  The id of the Cogniac EdgeFlow to return
-        url_prefix (String):  The local URL prefix of a EdgeFlow 
         """
-        return CogniacEdgeFlow.get(connection=self,
-                                  edgeflow_id=edgeflow_id,
-                                  url_prefix=url_prefix)
+        return CogniacEdgeFlow.get(self, edgeflow_id)
 
 
 if __name__ == "__main__":

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -445,14 +445,14 @@ class CogniacConnection(object):
         """
         return CogniacGateway.get_all(self)
 
-    def get_gateway(self, gateway_id=None, url_prefix=None):
+    def get_gateway(self, gateway_id, url_prefix=None):
         """
         return an existing CogniacGateway 
 
         gateway_id (String):  The id of the Cogniac Gateway to return
         url_prefix (String):  The local URL prefix of a Gateway
         """
-        return CogniacGateway.get(self,
+        return CogniacGateway.get(connection=self,
                                   gateway_id=gateway_id,
                                   url_prefix=url_prefix)
 

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -87,6 +87,8 @@ class CogniacEdgeFlow(object):
         # Validate IP address.
         if self.ip_address and IP_REGEX.match(self.ip_address):
             self.url_prefix = 'http://{}:8000/1'.format(self.ip_address)
+        else:
+            self.url_prefix = None
 
         self.timeout = timeout
 
@@ -97,7 +99,7 @@ class CogniacEdgeFlow(object):
             super(CogniacEdgeFlow, self).__setattr__(name, value)
             return
         data = {name: value}
-        resp = self._cc._post("/gateways/%s" % self.tenant_id, json=data)
+        resp = self._cc._post("/gateways/%s" % self.gateway_id, json=data)
         for k, v in resp.json().items():
             super(CogniacEdgeFlow, self).__setattr__(k, v)
 

--- a/cogniac/gateway.py
+++ b/cogniac/gateway.py
@@ -93,9 +93,6 @@ class CogniacGateway(object):
             gateway_dict = {}
         super(CogniacGateway, self).__setattr__('_gateway_keys', gateway_dict.keys())
 
-        if 'COG_GW_URL_PREFIX' in os.environ:
-            url_prefix = os.environ['COG_GW_URL_PREFIX']
-
         if not connection and not url_prefix:
             raise Exception("A URL must be specified for either a CloudCore or EdgeFlow API.")
 

--- a/cogniac/gateway.py
+++ b/cogniac/gateway.py
@@ -166,6 +166,10 @@ class CogniacGateway(object):
     #
     # -------------------------------------------------------------------------
 
+    def get_api_version(self):
+        resp = self._get("/version")
+        return resp.json()
+
     def process_media(self,
                       subject_uid,
                       filename,


### PR DESCRIPTION
### Changes
- Refactored `CogniacGateway` object to include APIs to send events to EF via CloudCore.
- Added `get_all_gateways` and `get_gateways` functions to `CogniacConnection` object.
- Added optional `url_prefix` parameter to `get_gateway` to use a local gateway. If no `url_prefix` is specified, local EF API calls will fail.
- Allow pure local interaction with EF by directly instantiating `CogniacGateway` with `url_prefix`. In this case, CloudCore APIs will fail.

### Next
- Don't add APIs specific to `network_interfaces` in this PR, create a follow-up issue to discuss. Suggest creating additional, distinct class for network interfaces such as `NetworkInterface`.
- Testing for different API usage cases introduced here.
- API Documentation and examples.