### PR TITLE
init python3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Python 2.7 SDK for Cogniac Public API
+Python SDK for Cogniac Public API
+
+Supported Python versions: Python 2.7 and Python 3
 
 This client library provides access to most of the common functionality of the Cogniac public API.
 

--- a/cogniac/__init__.py
+++ b/cogniac/__init__.py
@@ -141,7 +141,7 @@ CogniacTenant
 
 """
 
-from cogniac import CogniacConnection
+from .cogniac import CogniacConnection
 from .edgeflow import CogniacEdgeFlow
 from .app import CogniacApplication
 from .tenant import CogniacTenant

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -5,7 +5,7 @@ Copyright (C) 2016 Cogniac Corporation
 """
 
 from retrying import retry
-from common import server_error
+from .common import server_error
 
 
 class CogniacApplication(object):

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -14,16 +14,16 @@ from requests.auth import HTTPBasicAuth
 from requests.packages.urllib3 import Retry
 from requests.adapters import HTTPAdapter
 
-from common import server_error, raise_errors, CredentialError, credential_error
+from .common import server_error, raise_errors, CredentialError, credential_error
 
-from app     import CogniacApplication
-from subject import CogniacSubject
-from tenant  import CogniacTenant
-from user    import CogniacUser
-from media   import CogniacMedia
-from edgeflow import CogniacEdgeFlow
+from .app     import CogniacApplication
+from .subject import CogniacSubject
+from .tenant  import CogniacTenant
+from .user    import CogniacUser
+from .media   import CogniacMedia
+from .edgeflow import CogniacEdgeFlow
 
-from network_camera import CogniacNetworkCamera
+from .network_camera import CogniacNetworkCamera
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ class CogniacConnection(object):
                 tenant_id = os.environ['COG_TENANT']
             except:
                 if self.api_key:
-                    print "tenant_id must be explicitly specified when using api_key"
+                    print("tenant_id must be explicitly specified when using api_key")
                     raise Exception("Unspecified tenant")
 
                 # get list of user's tenants
@@ -147,10 +147,10 @@ class CogniacConnection(object):
                     tenant_id = tenants[0]['tenant_id']
                 else:
                     # try to be helpful and provider interactive user with a list of valid tenants
-                    print "\nError: must specify tenant (e.g. export COG_TENANT=... ) from the following choices:"
+                    print("\nError: must specify tenant (e.g. export COG_TENANT=... ) from the following choices:")
                     tenants.sort(key=lambda x: x['name'])
                     for tenant in tenants:
-                        print "%24s (%s)    export COG_TENANT='%s'" % (tenant['name'], tenant['tenant_id'], tenant['tenant_id'])
+                        print("%24s (%s)    export COG_TENANT='%s'" % (tenant['name'], tenant['tenant_id'], tenant['tenant_id']))
                     print
                     raise Exception("Unspecified tenant")
 
@@ -487,10 +487,10 @@ if __name__ == "__main__":
     c = CogniacConnection()
     tenant = c.tenant()
     from pprint import pprint
-    print tenant
-    print "\nApplications:"
+    print(tenant)
+    print("\nApplications:")
     for app in tenant.applications():
         pprint(app.name)
-    print "\Subjects:"
+    print("\Subjects:")
     for sub in tenant.subjects():
-        print sub.name, sub.subject_uid
+        print(sub.name, sub.subject_uid)

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -13,9 +13,9 @@ from requests.packages.urllib3 import Retry
 from requests.adapters import HTTPAdapter
 from time import time
 
-from common import server_error, raise_errors
+from .common import server_error, raise_errors
 
-from media import file_creation_time
+from .media import file_creation_time
 
 IP_REGEX = re.compile('^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$')
 

--- a/cogniac/external_results.py
+++ b/cogniac/external_results.py
@@ -6,7 +6,7 @@ Copyright (C) 2016 Cogniac Corporation
 
 from retrying import retry
 import sys
-from common import server_error
+from .common import server_error
 
 
 ##
@@ -104,7 +104,7 @@ class CogniacExternalResult(object):
                 data['limit'] = limit
 
         resp = connection._get("/externalResults", json=data)
-        print resp.json()
+        print(resp.json())
         subs = resp.json()['data']
         return [CogniacExternalResult(connection, s) for s in subs]
 

--- a/cogniac/media.py
+++ b/cogniac/media.py
@@ -6,7 +6,7 @@ Copyright (C) 2016 Cogniac Corporation
 
 from hashlib import md5
 from retrying import retry
-from common import *
+from .common import *
 from os import stat, path
 import platform
 
@@ -234,8 +234,8 @@ class CogniacMedia(object):
                 files = {filename: fp}
             else:
                 files = {filename: open(filename, 'rb')}
-            print args
-            print files
+            print(args)
+            print(files)
             resp = connection._post("/media", data=args, files=files)
             return resp
 

--- a/cogniac/network_camera.py
+++ b/cogniac/network_camera.py
@@ -6,7 +6,7 @@ Copyright (C) 2019 Cogniac Corporation
 
 from retrying import retry
 import sys
-from common import server_error
+from .common import server_error
 
 camera_model_keys = ['last_pose_change_timestamp',
                      'resolution_h_px', 'resolution_v_px',
@@ -333,7 +333,7 @@ class CogniacNetworkCamera(object):
 
         if name in mutable_keys:
             data = {name: value}
-            print "\n====", data
+            print("\n====", data)
             resp = self._cc._post("/networkCameras/%s" % self.network_camera_id, json=data)
 
             for k, v in resp.json().items():

--- a/cogniac/ops_review.py
+++ b/cogniac/ops_review.py
@@ -6,7 +6,7 @@ Copyright (C) 2016 Cogniac Corporation
 
 from retrying import retry
 import sys
-from common import server_error
+from .common import server_error
 
 
 ##

--- a/cogniac/subject.py
+++ b/cogniac/subject.py
@@ -5,10 +5,10 @@ Copyright (C) 2016 Cogniac Corporation
 """
 
 from retrying import retry
-from common import *
+from .common import *
 import sys
 
-from media import CogniacMedia
+from .media import CogniacMedia
 
 
 ##

--- a/cogniac/tenant.py
+++ b/cogniac/tenant.py
@@ -7,7 +7,7 @@ Copyright (C) 2016 Cogniac Corporation
 
 import json
 from retrying import retry
-from common import *
+from .common import *
 
 
 TENANT_ADMIN_ROLE = "tenant_admin"

--- a/cogniac/user.py
+++ b/cogniac/user.py
@@ -7,7 +7,7 @@ Copyright (C) 2019 Cogniac Corporation
 
 import json
 from retrying import retry
-from common import *
+from .common import *
 
 
 mutable_keys = ['given_name', 'surname', 'title']


### PR DESCRIPTION
I run this test and got not issues.

``` python
import cogniac

cc = cogniac.CogniacConnection(tenant_id="some_tenant")

apps = cc.get_all_applications()

print(apps)

subj = cc.get_subject("some_subject")

m = cc.create_media(filename="some-image.jpg")

subj.associate_media(m)
```

```
%python3 ./sdk_p3_test.py
...
%python3 --version
Python 3.8.4
```

At the same time python 2.7 can run it too.