### PR TITLE
fix: Add six library for python_2_unicode_compatible class decorator

### DIFF
--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -5,9 +5,11 @@ Copyright (C) 2016 Cogniac Corporation
 """
 
 from retrying import retry
+import six
 from .common import server_error
 
 
+@six.python_2_unicode_compatible
 class CogniacApplication(object):
     """
     CogniacApplication

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -168,8 +168,11 @@ class CogniacApplication(object):
 
         super(CogniacApplication, self).__setattr__(name, value)
 
-    def __repr__(self):
+    def __str__(self):
         return "%s (%s)" % (self.name, self.application_id)
+
+    def __repr__(self):
+        return self.__str__()
 
     def add_output_subject(self, subject):
         """

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -5,6 +5,7 @@ Copyright (C) 2016 Cogniac Corporation
 """
 
 import os
+import six
 import sys
 import requests
 import re
@@ -20,6 +21,7 @@ from .media import file_creation_time
 IP_REGEX = re.compile('^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$')
 
 
+@six.python_2_unicode_compatible
 class CogniacEdgeFlow(object):
     """
     CogniacEdgeFlow
@@ -105,12 +107,10 @@ class CogniacEdgeFlow(object):
             super(CogniacEdgeFlow, self).__setattr__(k, v)
 
     def __str__(self):
-        s = "%s (%s)" % (self.name, self.gateway_id)
-        return s.encode(sys.stdout.encoding)
+        return "%s (%s)" % (self.name, self.gateway_id)
 
     def __repr__(self):
-        s = "%s (%s)" % (self.name, self.gateway_id)
-        return s.encode(sys.stdout.encoding)
+        return self.__str__()
 
     # -------------------------------------------------------------------------
     #

--- a/cogniac/external_results.py
+++ b/cogniac/external_results.py
@@ -5,6 +5,7 @@ Copyright (C) 2016 Cogniac Corporation
 """
 
 from retrying import retry
+import six
 import sys
 from .common import server_error
 
@@ -12,6 +13,7 @@ from .common import server_error
 ##
 #  Cogniac External Result
 ##
+@six.python_2_unicode_compatible
 class CogniacExternalResult(object):
     """
     CogniacExternalResult
@@ -142,9 +144,7 @@ class CogniacExternalResult(object):
         super(CogniacExternalResult, self).__setattr__(name, value)
 
     def __str__(self):
-        s = "%s" % (self.external_result_id)
-        return s.encode(sys.stdout.encoding)
+        return "%s" % (self.external_result_id)
 
     def __repr__(self):
-        s = "%s" % (self.external_result_id)
-        return s.encode(sys.stdout.encoding)
+        return self.__str__()

--- a/cogniac/network_camera.py
+++ b/cogniac/network_camera.py
@@ -5,6 +5,7 @@ Copyright (C) 2019 Cogniac Corporation
 """
 
 from retrying import retry
+import six
 import sys
 from .common import server_error
 
@@ -32,6 +33,7 @@ immutable_keys = ['network_camera_id', 'created_at',
 ##
 #  Cogniac Network Camera
 ##
+@six.python_2_unicode_compatible
 class CogniacNetworkCamera(object):
     """
     CogniacNetworkCamera
@@ -344,9 +346,7 @@ class CogniacNetworkCamera(object):
         super(CogniacNetworkCamera, self).__setattr__(name, value)
 
     def __str__(self):
-        s = "%s (%s)" % (self.camera_name, self.network_camera_id)
-        return s.encode(sys.stdout.encoding)
+        return "%s (%s)" % (self.camera_name, self.network_camera_id)
 
     def __repr__(self):
-        s = "%s (%s)" % (self.camera_name, self.network_camera_id)
-        return s.encode(sys.stdout.encoding)
+        return self.__str__()

--- a/cogniac/ops_review.py
+++ b/cogniac/ops_review.py
@@ -5,6 +5,7 @@ Copyright (C) 2016 Cogniac Corporation
 """
 
 from retrying import retry
+import six
 import sys
 from .common import server_error
 
@@ -12,6 +13,7 @@ from .common import server_error
 ##
 #  Cogniac Ops Review
 ##
+@six.python_2_unicode_compatible
 class CogniacOpsReview(object):
     """
     CogniacOpsReview
@@ -211,9 +213,7 @@ class CogniacOpsReview(object):
         super(CogniacOpsReview, self).__setattr__(name, value)
 
     def __str__(self):
-        s = "%s" % (self.review_id)
-        return s.encode(sys.stdout.encoding)
+        return "%s" % (self.review_id)
 
     def __repr__(self):
-        s = "%s" % (self.review_id)
-        return s.encode(sys.stdout.encoding)
+        return self.__str__()

--- a/cogniac/subject.py
+++ b/cogniac/subject.py
@@ -6,6 +6,7 @@ Copyright (C) 2016 Cogniac Corporation
 
 from retrying import retry
 from .common import *
+import six
 import sys
 
 from .media import CogniacMedia
@@ -14,6 +15,7 @@ from .media import CogniacMedia
 ##
 #  CogniacSubject
 ##
+@six.python_2_unicode_compatible
 class CogniacSubject(object):
     """
     CogniacSubject
@@ -212,12 +214,10 @@ class CogniacSubject(object):
         super(CogniacSubject, self).__setattr__(name, value)
 
     def __str__(self):
-        s = "%s (%s)" % (self.name, self.subject_uid)
-        return s.encode(sys.stdout.encoding)
+        return "%s (%s)" % (self.name, self.subject_uid)
 
     def __repr__(self):
-        s = "%s (%s)" % (self.name, self.subject_uid)
-        return s.encode(sys.stdout.encoding)
+        return self.__str__()
 
     ##
     #  dissassociate_media

--- a/cogniac/tenant.py
+++ b/cogniac/tenant.py
@@ -6,6 +6,7 @@ Copyright (C) 2016 Cogniac Corporation
 """
 
 import json
+import six
 from retrying import retry
 from .common import *
 
@@ -19,6 +20,7 @@ TENANT_BILLING_ROLE = "tenant_billing"
 ##
 #   CogniacTenant
 ##
+@six.python_2_unicode_compatible
 class CogniacTenant(object):
 
     @classmethod
@@ -37,7 +39,7 @@ class CogniacTenant(object):
         return "%s (%s)" % (self.name, self.tenant_id)
 
     def __repr__(self):
-        return "%s (%s)" % (self.name, self.tenant_id)
+        return self.__str__()
 
     def __setattr__(self, name, value):
         if name not in self._tenant_keys:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 retrying
 requests
+six
 tabulate
-


### PR DESCRIPTION
This allows for py2 and py3 compatible __str__() methods