### PR TITLE
Add new `reviewers` field to application object in support of upcoming feedback revisions.

### DIFF
--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -163,7 +163,8 @@ class CogniacApplication(object):
 
         if name in ['name', 'description', 'active', 'input_subjects', 'output_subjects', 'app_managers',
                     'detection_post_urls', 'detection_thresholds', 'custom_fields', 'app_type_config',
-                    'edgeflow_upload_policies', 'override_upstream_detection_filter', 'feedback_resample_ratio']:
+                    'edgeflow_upload_policies', 'override_upstream_detection_filter', 'feedback_resample_ratio',
+                    'reviewers']:
             data = {name: value}
             self.__post_update__(data)
             return

--- a/cogniac/subject.py
+++ b/cogniac/subject.py
@@ -220,6 +220,114 @@ class CogniacSubject(object):
         return s.encode(sys.stdout.encoding)
 
     ##
+    #  create_reference_media
+    ##
+    @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
+    def create_reference_media(self,
+                               filename,
+                               meta_tags=None,
+                               force_set=None,
+                               set_assignment=None,
+                               external_media_id=None,
+                               original_url=None,
+                               original_landing_url=None,
+                               license=None,
+                               author_profile_url=None,
+                               author=None,
+                               title=None,
+                               media_timestamp=None,
+                               domain_unit=None,
+                               trigger_id=None,
+                               sequence_ix=None,
+                               custom_data=None,
+                               fp=None):
+        """
+        Create a new CogniacMedia object, upload the media to the Cogniac
+        System, and set it as the subject's reference media.
+
+        connnection (CogniacConnection):  Authenticated CogniacConnection object
+        filename (str):                   Local filename or http/s URL of image or video media file
+        meta_tags ([str]):                Optional list of arbitrary strings to associate with the media
+        force_set (str):                  [DEPRECATED] Optionally force the media into the 'training', 'validation' or 'test' sets
+        set_assignment (str):             Optionally force the media into the 'training', 'validation' or 'test' sets
+        external_media_id (str):          Optional arbitrary external id for this media
+        original_url(str):                Optional source url for this media
+        original_landing_url (str):       Optional source landing url for this media
+        license (str):                    Optional copyright licensing info for this media
+        author_profile_url (str):         Optional media author url
+        author (str):                     Optional author name
+        title (str):                      Optional media title
+        media_timestamp (float):          Optional actual timestamp of media creation/occurance time
+        domain_unit (str):                Optional domain id (e.g. serial number) for set assignment grouping.
+                                          Media with the same domain_unit will always be assigned to the same
+                                          training or validation set. Set this to avoid overfitting when you have
+                                          multiple images of the same thing or almost the same thing.
+        trigger_id (str):                 Unique trigger identifier leading to a media sequence containing this media
+        sequence_ix (str):                The index of this media within a triggered sequence
+        custom_data (str):                Opaque user-specified data associated with this media; limited to 32KB
+        fp (file):                        A '.read()'-supporting file-like object (under 16MB) from which to acquire
+                                          the media instead of reading the media from the specified filename.
+        """
+        args = dict()
+        if meta_tags is not None:
+            args['meta_tags'] = meta_tags
+        if force_set is not None:
+            args['force_set'] = force_set
+        if set_assignment is not None:
+            args['set_assignment'] = set_assignment
+        if external_media_id is not None:
+            args['external_media_id'] = external_media_id
+        if original_url is not None:
+            args['original_url'] = original_url
+        if original_landing_url is not None:
+            args['original_landing_url'] = original_landing_url
+        if license is not None:
+            args['license'] = license
+        if author_profile_url is not None:
+            args['author_profile_url'] = author_profile_url
+        if author is not None:
+            args['author'] = author
+        if title is not None:
+            args['title'] = title
+        if media_timestamp is not None:
+            args['media_timestamp'] = media_timestamp
+        if domain_unit is not None:
+            args['domain_unit'] = domain_unit
+        if trigger_id is not None:
+            args['trigger_id'] = trigger_id
+        if sequence_ix is not None:
+            args['sequence_ix'] = sequence_ix
+        if custom_data is not None:
+            args['custom_data'] = custom_data
+
+        if filename.startswith('http'):
+            args['source_url'] = filename
+        elif fp is None:  # local filename
+            fstat = stat(filename)
+            if 'media_timestamp' not in args:
+                # set the unspecified media timestamp to the earliest file time we have
+                args['media_timestamp'] = file_creation_time(filename)
+            if stat(filename).st_size > 12 * 1024 * 1024:
+                # use the multipart interface for large files
+                return CogniacMedia._create_multipart(self.connection, filename, args)
+
+        @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
+        def upload():
+            if filename.startswith('http'):
+                files = None
+            elif fp is not None:
+                fp.seek(0)  # for the retry win
+                files = {'file': fp}
+            else:
+                files = {'file': open(filename, 'rb')}
+                # api.add_resource(SubjectReferenceMedia, '/1/subjects/<string:subject_uid>/referenceMedia')
+            resp = self._cc._post("/subjects/{}/referenceMedia".format(self.subject_uid), data=args, files=files)
+            return resp
+
+        resp = upload()
+        return CogniacMedia(self._cc, resp.json())
+
+    ##
     #  dissassociate_media
     ##
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)


### PR DESCRIPTION
This field is being added to support the addition of an application reviewer assignment feature, which allows an application manager to assign specific Cogniac users as a reviewer of an application, which is a user that can provide "feedback" (e.g., bounding boxes and labels in the case of the box detection application type).

Assigned application reviewers must be assigned one of the two currently-supported application reviewer roles: (1) "reviewer", or (2) "annotator".

Users can be assigned as application reviewers by adding them into the `reviewers` field (list) in the application object at application creation time or by updating the application. For example, to update an application to assign a reviewer with the "reviewer" role:

```
POST /1/applications/{application_id}

{
    "reviewers": [
        {
            "user_email": "tenant.user@domain.com",
            "role": "reviewer"
        }
    ]
}
```

Note, "reviewer" could be replaced with "annotator" in the above example to assign the application reviewer with the annotator role.

**Notes:**
- The _reviewer role_ concept here pertains only to assignment of roles of assigned application reviewers and is distinct from the _tenant role_ assigned to users added to a tenant.
- As illustrated in the above example, each assigned application reviewer can be assigned exactly one application reviewer role.
- Each application can be assigned some reviewers with the "reviewer" role and some reviewers with the "annotator" role (e.g., 3 with "reviewer" and 6 with "annotator").
- Any application manager can add or update application reviewers and roles.
- When assigning or updating application reviewers, the entire `reviewers` list must be specified in the POST request to create or update an application (the default behavior of lists in the Cogniac Public API).