### PR TITLE
Add support setting "Sidelined" consensus type on a subject media association.

### DIFF
--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -230,7 +230,7 @@ class CogniacApplication(object):
         subjects (list of dicts):      Subject-media association dictionaries of the form:
 
             subject_uid:               Subject UID
-            result (str):              Either 'True', 'False', 'Uncertain'
+            result (str):              One of 'True', 'False', 'Uncertain', 'Sidelined'
             app_data_type (String):    (Optional) Type of extra app-specific data for certain app types
             app_data (Object):         (Optional) Additional, app-specific, subject-media association data
 

--- a/cogniac/media.py
+++ b/cogniac/media.py
@@ -400,8 +400,8 @@ class CogniacMedia(object):
                         'False' if there is consensus that the subject is not associated w/the media
                             (Media will be used as a negative training example of the subject.)
                          None if if there is not enough evidence to reach consensus
-                         'Sidelined' if there is consensus that the media could not be considered
-                            associated with the subject.
+                         'Sidelined' if there is consensus that the media should not be used 
+                            for training applications dependent on the subject.
                          Some application types only support 'True' or None.
                          }
         """

--- a/cogniac/media.py
+++ b/cogniac/media.py
@@ -394,12 +394,14 @@ class CogniacMedia(object):
         timestamp		time of last update
         app_data_type	optional app data type if applicable
         app_data        optional app data if applicable
-        consensus		'True', 'False', or None
+        consensus		'True', 'False', 'Sidelined', or None
                         'True' if there is consensus that the subject is associated with the media
                             (Media will be used as a positive training example of the subject)
                         'False' if there is consensus that the subject is not associated w/the media
                             (Media will be used as a negative training example of the subject.)
                          None if if there is not enough evidence to reach consensus
+                         'Sidelined' if there is consensus that the media could not be considered
+                            associated with the subject.
                          Some application types only support 'True' or None.
                          }
         """

--- a/cogniac/subject.py
+++ b/cogniac/subject.py
@@ -375,6 +375,7 @@ class CogniacSubject(object):
                                          'box'     Optional dictionary of bounding box pixel offsets (with keys x0, x1, y0, y1) within the frame.
         consensus (str)                  'True' if media is associated with subject,
                                          'False' if media is NOT associated with subject.
+                                         'Sidelined' if consensus was decisively not provided.
                                          'None' if consenus is unknown.  Required uncal_prob
         probability (float)              association probability, only valid if consensus = 'None'
         force_feedback (bool)            True to force feedback on the media item in downstream apps
@@ -398,7 +399,7 @@ class CogniacSubject(object):
         if focus is not None:
             data['focus'] = focus
 
-        assert(consensus in ['True', 'False', 'None'])
+        assert(consensus in ['True', 'False', 'None', 'Sidelined'])
         data['consensus'] = consensus
 
         if consensus is 'None' and probability is None:
@@ -450,11 +451,12 @@ class CogniacSubject(object):
         timestamp	time of last update to subject media association
         app_data_type	optional app data type if applicable
         app_data        optional app data if applicable
-        consensus		'True', 'False', or , or None
+        consensus		'True', 'False', or 'Sidelined', or None
                         'True' if there is consensus that the subject is associated with the media
                             (Media will be used as a positive training example of the subject)
                         'False' if there is consensus that the subject is not associated w/the media
                             (Media will be used as a negative training example of the subject.)
+                        'Sidelined' if the media's association with the subject was decisively not provided. 
                          None if if there is not enough evidence to reach consensus
                          Some application types only support 'True' or None.
         """
@@ -469,7 +471,7 @@ class CogniacSubject(object):
         if probability_upper is not None:
             args.append("probability_upper=%f" % probability_upper)
         if consensus is not None:
-            assert(consensus in ['True', 'False'])
+            assert(consensus in ['True', 'False', 'Sidelined'])
             args.append("consensus=%s" % consensus)
         if reverse:
             args.append('reverse=True')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='cogniac',
-      version='2.0.6',
+      version='2.0.7',
       description='Python SDK for Cogniac Public API',
       packages=['cogniac'],
       author = 'Cogniac Corporation',


### PR DESCRIPTION
Resolves https://github.com/Cogniac/CloudCore/issues/167.

This supports the addition of the "Sidelined" consensus type for applications to enable application reviewers to "sideline" media when providing feedback, meant to indicate the media is impossible to review or label with certainty (e.g., image is corrupt or somehow doesn't represent a typical image for an application).