### PR TITLE
Move API version out of URL prefix in core requests wrapper to enable per-endpoint versioning.

### DIFF
--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -202,7 +202,7 @@ class CogniacApplication(object):
         Return the integer number of feedback requests pending for this application.
         This is useful for controlling the flow of images input into the system to avoid creating too many backlogged feedback requests.
         """
-        resp = self._cc._get("/21/applications/%s/feedback/pending" % self.application_id)
+        resp = self._cc._get("/1/applications/%s/feedback/pending" % self.application_id)
         return resp.json()['pending']
 
     ##
@@ -215,7 +215,7 @@ class CogniacApplication(object):
 
         limit (Int):   Maximum number of feedback request messages to return
         """
-        resp = self._cc._get("/21/applications/%s/feedback?limit=%d" % (self.application_id, limit))
+        resp = self._cc._get("/1/applications/%s/feedback?limit=%d" % (self.application_id, limit))
         return resp.json()
 
     ##
@@ -243,7 +243,7 @@ class CogniacApplication(object):
         feedback_response = {'media_id': media_id,
                              'subjects': subjects}
 
-        self._cc._post("/21/applications/%s/feedback" % self.application_id, json=feedback_response)
+        self._cc._post("/1/applications/%s/feedback" % self.application_id, json=feedback_response)
 
     ##
     #  list of models released

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -74,7 +74,7 @@ class CogniacApplication(object):
         if app_managers is not None:
             data['app_managers'] = app_managers
 
-        resp = connection._post("/applications", json=data)
+        resp = connection._post("/1/applications", json=data)
 
         return CogniacApplication(connection, resp.json())
 
@@ -92,7 +92,7 @@ class CogniacApplication(object):
         connnection (CogniacConnection):     Authenticated CogniacConnection object
         application_id (String):             The application_id of the Cogniac application to return
         """
-        resp = connection._get("/applications/%s" % application_id)
+        resp = connection._get("/1/applications/%s" % application_id)
         return CogniacApplication(connection, resp.json())
 
     ##
@@ -105,7 +105,7 @@ class CogniacApplication(object):
 
         connnection (CogniacConnection):     Authenticated CogniacConnection object
         """
-        resp = connection._get('/tenants/%s/applications' % connection.tenant.tenant_id)
+        resp = connection._get('/1/tenants/%s/applications' % connection.tenant.tenant_id)
         apps = resp.json()['data']
         return [CogniacApplication(connection, appd) for appd in apps]
 
@@ -142,7 +142,7 @@ class CogniacApplication(object):
         Delete the application.
         This will delete existing models but will not delete associated subjects or media.
         """
-        self._cc._delete("/applications/%s" % self.application_id)
+        self._cc._delete("/1/applications/%s" % self.application_id)
 
         for k in self._app_keys:
             delattr(self, k)
@@ -151,7 +151,7 @@ class CogniacApplication(object):
         self.connection = None
 
     def __post_update__(self, data):
-        resp = self._cc._post("/applications/%s" % self.application_id, json=data)
+        resp = self._cc._post("/1/applications/%s" % self.application_id, json=data)
         self.__parse_app_dict__(resp.json())
 
     def __setattr__(self, name, value):
@@ -202,7 +202,7 @@ class CogniacApplication(object):
         Return the integer number of feedback requests pending for this application.
         This is useful for controlling the flow of images input into the system to avoid creating too many backlogged feedback requests.
         """
-        resp = self._cc._get("/applications/%s/feedback/pending" % self.application_id)
+        resp = self._cc._get("/21/applications/%s/feedback/pending" % self.application_id)
         return resp.json()['pending']
 
     ##
@@ -215,7 +215,7 @@ class CogniacApplication(object):
 
         limit (Int):   Maximum number of feedback request messages to return
         """
-        resp = self._cc._get("/applications/%s/feedback?limit=%d" % (self.application_id, limit))
+        resp = self._cc._get("/21/applications/%s/feedback?limit=%d" % (self.application_id, limit))
         return resp.json()
 
     ##
@@ -243,7 +243,7 @@ class CogniacApplication(object):
         feedback_response = {'media_id': media_id,
                              'subjects': subjects}
 
-        self._cc._post("/applications/%s/feedback" % self.application_id, json=feedback_response)
+        self._cc._post("/21/applications/%s/feedback" % self.application_id, json=feedback_response)
 
     ##
     #  list of models released
@@ -267,7 +267,7 @@ class CogniacApplication(object):
             assert(limit > 0)
             args.append('limit=%d' % min(limit, 100))  # api support max limit of 100
 
-        url = "/applications/%s/models?" % self.application_id
+        url = "/1/applications/%s/models?" % self.application_id
         url += "&".join(args)
 
         @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
@@ -299,7 +299,7 @@ class CogniacApplication(object):
         """
         return the modelname for the current best model for this application
         """
-        resp = self._cc._get("/applications/%s/ccp" % self.application_id)
+        resp = self._cc._get("/1/applications/%s/ccp" % self.application_id)
         resp = resp.json()
 
         url = resp['best_model_ccp_url']
@@ -316,14 +316,14 @@ class CogniacApplication(object):
         return the local filename which will be the same as the model name.
         """
         if model_id is None:
-            resp = self._cc._get("/applications/%s/ccp" % self.application_id)
+            resp = self._cc._get("/1/applications/%s/ccp" % self.application_id)
             resp = resp.json()
             url = resp['best_model_ccp_url']
             modelname = url.split('/')[-1]
         else:
             modelname = model_id.split('/')[-1]
 
-        resp = self._cc._get("/applications/%s/ccppkg" % self.application_id, json={"ccp_filename": modelname})
+        resp = self._cc._get("/1/applications/%s/ccppkg" % self.application_id, json={"ccp_filename": modelname})
 
         fp = open(modelname, "wb")
         fp.write(resp.content)
@@ -395,7 +395,7 @@ class CogniacApplication(object):
         if abridged_media:
             args.append('abridged_media=True')
 
-        url = "/applications/%s/detections?" % self.application_id
+        url = "/1/applications/%s/detections?" % self.application_id
         url += "&".join(args)
 
         @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
@@ -417,7 +417,7 @@ class CogniacApplication(object):
         """
         return single cummulative app usage record for start to end epoch times
         """
-        url = "/usage/app/%s?start=%d&end=%d&accumulate=True" % (self.application_id, start, end)
+        url = "/1/usage/app/%s?start=%d&end=%d&accumulate=True" % (self.application_id, start, end)
         resp = self._cc._get(url)
         data = resp.json()['data']
         return data[0] if len(data) else None
@@ -426,7 +426,7 @@ class CogniacApplication(object):
         """
         yield sparse app usage records in order between start and end epoch times
         """
-        url = "/usage/app/%s?start=%d&end=%d" % (self.application_id, start, end)
+        url = "/1/usage/app/%s?start=%d&end=%d" % (self.application_id, start, end)
 
         @retry(stop_max_attempt_number=8, wait_exponential_multiplier=5, retry_on_exception=server_error)
         def get_next(url):

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -46,12 +46,12 @@ class CogniacConnection(object):
 
     @classmethod
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
-    def get_all_authorized_tenants(cls, username=None, password=None, url_prefix="https://api.cogniac.io/1"):
+    def get_all_authorized_tenants(cls, username=None, password=None, url_prefix="https://api.cogniac.io/"):
         """
         return the list of valid tenants for the specified user credentials and url_prefix
         """
         if 'COG_API_KEY' in os.environ:
-            resp = requests.get(url_prefix + "/users/current/tenants",
+            resp = requests.get(url_prefix + "/1/users/current/tenants",
                                 headers={"Authorization": "Key %s" % os.environ['COG_API_KEY']})
             raise_errors(resp)
             return resp.json()
@@ -64,7 +64,7 @@ class CogniacConnection(object):
             except:
                 raise Exception("No Cogniac Credentials. Try setting COG_USER and COG_PASS environment.")
 
-        resp = requests.get(url_prefix + "/users/current/tenants", auth=HTTPBasicAuth(username, password))
+        resp = requests.get(url_prefix + "/1/users/current/tenants", auth=HTTPBasicAuth(username, password))
         raise_errors(resp)
         return resp.json()
 
@@ -74,7 +74,7 @@ class CogniacConnection(object):
                  api_key=None,
                  tenant_id=None,
                  timeout=60,
-                 url_prefix="https://api.cogniac.io/1"):
+                 url_prefix="https://api.cogniac.io/"):
         """
         Create an authenticated CogniacConnection with the following credentials:
 
@@ -126,6 +126,8 @@ class CogniacConnection(object):
 
         if 'COG_URL_PREFIX' in os.environ:
             url_prefix = os.environ['COG_URL_PREFIX']
+        if url_prefix.endswith('/'):
+            url_prefix = url_prefix[0:-1]
 
         self.url_prefix = url_prefix
         self.timeout = timeout
@@ -166,7 +168,7 @@ class CogniacConnection(object):
         if self.tenant.region is not None:
             # use tenant object's specified region preference
             # print "Using API endpoint from Tenant:", self.tenant.region
-            self.url_prefix = 'https://' + self.tenant.region + '/1'
+            self.url_prefix = 'https://' + self.tenant.region
 
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
     def __authenticate(self):
@@ -175,13 +177,13 @@ class CogniacConnection(object):
         tenant_data = {"tenant_id": self.tenant_id}
         if self.api_key:
             # trade API KEY for user+tenant token
-            resp = requests.get(self.url_prefix + "/token",
+            resp = requests.get(self.url_prefix + "/1/token",
                                 params=tenant_data,
                                 headers={"Authorization": "Key %s" % self.api_key},
                                 timeout=self.timeout)
         else:
             # trade username/password for user+tenant token
-            resp = requests.get(self.url_prefix + "/token",
+            resp = requests.get(self.url_prefix + "/1/token",
                                 params=tenant_data,
                                 auth=HTTPBasicAuth(self.username, self.password),
                                 timeout=self.timeout)

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -449,9 +449,9 @@ class CogniacConnection(object):
         returns json version info
         """
         if auth:
-            url = self.url_prefix + "/authversion"
+            url = self.url_prefix + "/1/authversion"
         else:
-            url = self.url_prefix + "/version"
+            url = self.url_prefix + "/1/version"
         resp = self._get(url)
         raise_errors(resp)
         return resp.json()

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -8,6 +8,7 @@ Copyright (C) 2016 Cogniac Corporation.
 
 import os
 import logging
+import re
 import requests
 from retrying import retry
 from requests.auth import HTTPBasicAuth
@@ -126,6 +127,10 @@ class CogniacConnection(object):
 
         if 'COG_URL_PREFIX' in os.environ:
             url_prefix = os.environ['COG_URL_PREFIX']
+        m = re.search(r'/\d+(/)?$', url_prefix)
+        # Strip API version number and tailing '/' from URL prefix.
+        if m is not None:
+            url_prefix = url_prefix[0:m.span()[0]]
         if url_prefix.endswith('/'):
             url_prefix = url_prefix[0:-1]
 

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -58,7 +58,7 @@ class CogniacEdgeFlow(object):
         returns CogniacEdgeFlow object
         """
         edgeflow_dict = None
-        resp = connection._get("/gateways/{}".format(edgeflow_id))
+        resp = connection._get("/1/gateways/{}".format(edgeflow_id))
         return CogniacEdgeFlow(connection, resp.json())
 
     @classmethod
@@ -68,7 +68,7 @@ class CogniacEdgeFlow(object):
 
         connnection (CogniacConnection):     Authenticated CogniacConnection object
         """
-        resp = connection._get('/tenants/%s/gateways' % connection.tenant.tenant_id)
+        resp = connection._get('/1/tenants/%s/gateways' % connection.tenant.tenant_id)
         edgeflows = resp.json()['data']
         return [CogniacEdgeFlow(connection, edgeflow) for edgeflow in edgeflows]
 
@@ -102,7 +102,7 @@ class CogniacEdgeFlow(object):
             super(CogniacEdgeFlow, self).__setattr__(name, value)
             return
         data = {name: value}
-        resp = self._cc._post("/gateways/%s" % self.gateway_id, json=data)
+        resp = self._cc._post("/1/gateways/%s" % self.gateway_id, json=data)
         for k, v in resp.json().items():
             super(CogniacEdgeFlow, self).__setattr__(k, v)
 
@@ -160,7 +160,7 @@ class CogniacEdgeFlow(object):
         return resp
 
     def get_version(self):
-        resp = self._get("/version")
+        resp = self._get("/1/version")
         return resp.json()
 
     def process_media(self,
@@ -210,7 +210,7 @@ class CogniacEdgeFlow(object):
                 raise Exception("The media file must be uploaded from local storage.")
             else:
                 files = {'file': open(filename, 'rb')}
-            resp = self._post("/process/{}".format(subject_uid), data=args, files=files)
+            resp = self._post("/1/process/{}".format(subject_uid), data=args, files=files)
             return resp
 
         resp = upload()
@@ -230,7 +230,7 @@ class CogniacEdgeFlow(object):
         args = dict()
         args['start_time'] = start_time
         args['end_time'] = end_time
-        self._cc._post("/gateways/%s/event/time_bound_media_upload" % (self.gateway_id), json=args)
+        self._cc._post("/1/gateways/%s/event/time_bound_media_upload" % (self.gateway_id), json=args)
 
 
     def flush_upload_queue(self, start_time=None, end_time=None):
@@ -242,7 +242,7 @@ class CogniacEdgeFlow(object):
             args['start_time'] = start_time
         if end_time is not None:
             args['end_time'] = end_time
-        self._cc._post("/gateways/%s/event/flush_upload_queue" % (self.gateway_id), json=args)
+        self._cc._post("/1/gateways/%s/event/flush_upload_queue" % (self.gateway_id), json=args)
 
 
     def factory_reset(self):
@@ -250,7 +250,7 @@ class CogniacEdgeFlow(object):
         Factory reset the EdgeFlow.
         This results in deletion of this EdgeFlow object in CloudCore/SiteCore!
         """
-        self._cc._post("/gateways/%s/event/factory_reset" % (self.gateway_id))
+        self._cc._post("/1/gateways/%s/event/factory_reset" % (self.gateway_id))
 
     def upgrade(self, software_version):
         """
@@ -259,7 +259,7 @@ class CogniacEdgeFlow(object):
         args = dict()
         if software_version is not None:
             args['software_version'] = software_version
-        self._cc._post("/gateways/%s/event/upgrade" % (self.gateway_id), json=args)
+        self._cc._post("/1/gateways/%s/event/upgrade" % (self.gateway_id), json=args)
 
     def set_boot_software_version(self, software_version):
         """
@@ -268,13 +268,13 @@ class CogniacEdgeFlow(object):
         args = dict()
         if software_version is not None:
             args['software_version'] = software_version
-        self._cc._post("/gateways/%s/event/set_boot_software_version" % (self.gateway_id), json=args)
+        self._cc._post("/1/gateways/%s/event/set_boot_software_version" % (self.gateway_id), json=args)
 
     def reboot(self):
         """
         Reboot the EdgeFlow
         """
-        self._cc._post("/gateways/%s/event/reboot" % (self.gateway_id))
+        self._cc._post("/1/gateways/%s/event/reboot" % (self.gateway_id))
 
     def ping(self, ping_id=None):
         """
@@ -284,7 +284,7 @@ class CogniacEdgeFlow(object):
         event = {"timestamp": time()}
         if ping_id is not None:
             event['ping_id'] = ping_id
-        self._cc._post("/gateways/%s/event/ping" % self.gateway_id, json=event)
+        self._cc._post("/1/gateways/%s/event/ping" % self.gateway_id, json=event)
 
     def trigger_camera_capture(self, subject_uid, trigger_domain_unit=None):
         """
@@ -294,7 +294,7 @@ class CogniacEdgeFlow(object):
         event = {'subject_uid': subject_uid}
         if trigger_domain_unit is not None:
             event['trigger_domain_unit'] = trigger_domain_unit
-        self._cc._post("/gateways/%s/event/trigger_camera_capture" % self.gateway_id, json=event)
+        self._cc._post("/1/gateways/%s/event/trigger_camera_capture" % self.gateway_id, json=event)
 
     def status(self, subsystem_name=None, start=None, end=None, reverse=True, limit=None):
         """
@@ -317,9 +317,9 @@ class CogniacEdgeFlow(object):
             args.append('limit=%d' % min(limit, 100))  # api support max limit of 100
 
         if subsystem_name:
-            url = "/gateways/%s/status/%s?" % (self.gateway_id, subsystem_name)
+            url = "/1/gateways/%s/status/%s?" % (self.gateway_id, subsystem_name)
         else:
-            url = "/gateways/%s/status?" % self.gateway_id
+            url = "/1/gateways/%s/status?" % self.gateway_id
 
         url += "&".join(args)
 

--- a/cogniac/external_results.py
+++ b/cogniac/external_results.py
@@ -49,7 +49,7 @@ class CogniacExternalResult(object):
         if domain_unit:
             data['domain_unit'] = domain_unit
 
-        resp = connection._post("/externalResults", json=data)
+        resp = connection._post("/1/externalResults", json=data)
         return CogniacExternalResult(connection, resp.json())
 
     ##
@@ -66,7 +66,7 @@ class CogniacExternalResult(object):
         connnection (CogniacConnection): Authenticated CogniacConnection object
         external_result_id (String):     The id of the Cogniac External Result to return
         """
-        resp = connection._get("/externalResults/%s" % external_result_id)
+        resp = connection._get("/1/externalResults/%s" % external_result_id)
         return CogniacExternalResult(connection, resp.json())
 
     ##
@@ -105,7 +105,7 @@ class CogniacExternalResult(object):
             if limit:
                 data['limit'] = limit
 
-        resp = connection._get("/externalResults", json=data)
+        resp = connection._get("/1/externalResults", json=data)
         print(resp.json())
         subs = resp.json()['data']
         return [CogniacExternalResult(connection, s) for s in subs]
@@ -133,7 +133,7 @@ class CogniacExternalResult(object):
         """
         Delete the external result.
         """
-        resp = self._cc._delete("/externalResults/%s" % self.external_result_id)
+        resp = self._cc._delete("/1/externalResults/%s" % self.external_result_id)
 
         for k in self._sub_keys:
             delattr(self, k)

--- a/cogniac/media.py
+++ b/cogniac/media.py
@@ -53,7 +53,7 @@ class CogniacMedia(object):
         connnection (CogniacConnection):     Authenticated CogniacConnection object
         media_id (String):                   The media_id of the Cogniac Media item to return
         """
-        resp = connection._get("/media/%s" % media_id)
+        resp = connection._get("/1/media/%s" % media_id)
 
         return CogniacMedia(connection, resp.json())
 
@@ -87,7 +87,7 @@ class CogniacMedia(object):
 
         def get_next(last_key=None):
             query_limit = limit if limit and limit < 100 else 100
-            url = "/media/all/search?%s&limit=%s" % (query, query_limit)
+            url = "/1/media/all/search?%s&limit=%s" % (query, query_limit)
             if last_key:
                 url += "&last_key=%s" % (last_key)
             resp = connection._get(url)
@@ -129,7 +129,7 @@ class CogniacMedia(object):
             raise AttributeError("%s is immutable" % name)
         if name in mutable_keys:
             data = {name: value}
-            resp = self._cc._post("/media/%s" % self.media_id, json=data)
+            resp = self._cc._post("/1/media/%s" % self.media_id, json=data)
             for k, v in resp.json().items():
                 super(CogniacMedia, self).__setattr__(k, v)
             return
@@ -240,7 +240,7 @@ class CogniacMedia(object):
                 files = {filename: fp}
             else:
                 files = {filename: open(filename, 'rb')}
-            resp = connection._post("/media", data=args, files=files)
+            resp = connection._post("/1/media", data=args, files=files)
             return resp
 
         resp = upload()
@@ -271,7 +271,7 @@ class CogniacMedia(object):
 
         @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
         def post_data(data):
-            resp = connection._post("/media/resumable", json=data)
+            resp = connection._post("/1/media/resumable", json=data)
             return resp.json()
 
         data = {'upload_phase': 'start',
@@ -291,7 +291,7 @@ class CogniacMedia(object):
                     'video_file_chunk_no': chunk_no}
 
             files = {'file': chunk}
-            resp = connection._post("/media/resumable", data=data, files=files)
+            resp = connection._post("/1/media/resumable", data=data, files=files)
             return resp.json()
 
         idx = 1
@@ -314,7 +314,7 @@ class CogniacMedia(object):
         """
         delete the media object
         """
-        self._cc._delete("/media/%s" % self.media_id)
+        self._cc._delete("/1/media/%s" % self.media_id)
         self.__dict__.clear()
 
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
@@ -371,7 +371,7 @@ class CogniacMedia(object):
         app_data          Optional extra app-specific data
         """
 
-        url = "/media/%s/detections" % (self.media_id)
+        url = "/1/media/%s/detections" % (self.media_id)
 
         if wait_capture_id is not None:
             url += "?wait_capture_id=%s" % wait_capture_id
@@ -409,5 +409,5 @@ class CogniacMedia(object):
                          Some application types only support 'True' or None.
                          }
         """
-        resp = self._cc._get("/media/%s/subjects" % (self.media_id))
+        resp = self._cc._get("/1/media/%s/subjects" % (self.media_id))
         return resp.json()['data']

--- a/cogniac/network_camera.py
+++ b/cogniac/network_camera.py
@@ -131,7 +131,7 @@ class CogniacNetworkCamera(object):
         if user_defined_name:
             data['user_defined_name'] = user_defined_name
 
-        resp = connection._post("/networkCameras", json=data)
+        resp = connection._post("/1/networkCameras", json=data)
         return CogniacNetworkCamera(connection, resp.json())
 
     ##
@@ -148,7 +148,7 @@ class CogniacNetworkCamera(object):
         network_camera_id (String): the netcam id of the Cogniac NetCam object
         returns CogniacNetworkCamera object
         """
-        resp = connection._get("/networkCameras/%s" % network_camera_id)
+        resp = connection._get("/1/networkCameras/%s" % network_camera_id)
         return CogniacNetworkCamera(connection, resp.json())
 
     ##
@@ -161,7 +161,7 @@ class CogniacNetworkCamera(object):
 
         connnection (CogniacConnection):     Authenticated CogniacConnection object
         """
-        resp = connection._get('/tenants/%s/networkCameras' % connection.tenant.tenant_id)
+        resp = connection._get('/1/tenants/%s/networkCameras' % connection.tenant.tenant_id)
         netcams = resp.json()['data']
         return [CogniacNetworkCamera(connection, netcam) for netcam in netcams]
 
@@ -295,7 +295,7 @@ class CogniacNetworkCamera(object):
         if z_axis_y is not None:
             data['z_axis_y'] = z_axis_y
 
-        resp = self._cc._post("/networkCameras/%s" % self.network_camera_id, json=data)
+        resp = self._cc._post("/1/networkCameras/%s" % self.network_camera_id, json=data)
         return CogniacNetworkCamera(self._cc, resp.json())
 
     ##
@@ -306,7 +306,7 @@ class CogniacNetworkCamera(object):
         """
         Delete the op review result.
         """
-        self._cc._delete("/networkCameras/%s" % self.network_camera_id)
+        self._cc._delete("/1/networkCameras/%s" % self.network_camera_id)
 
         for k in self._cam_keys:
             delattr(self, k)
@@ -336,7 +336,7 @@ class CogniacNetworkCamera(object):
         if name in mutable_keys:
             data = {name: value}
             print("\n====", data)
-            resp = self._cc._post("/networkCameras/%s" % self.network_camera_id, json=data)
+            resp = self._cc._post("/1/networkCameras/%s" % self.network_camera_id, json=data)
 
             for k, v in resp.json().items():
                 super(CogniacNetworkCamera, self).__setattr__(k, v)

--- a/cogniac/ops_review.py
+++ b/cogniac/ops_review.py
@@ -53,7 +53,7 @@ class CogniacOpsReview(object):
         if review_unit:
             data['review_unit'] = review_unit
 
-        resp = connection._post("/ops/review", json=data)
+        resp = connection._post("/1/ops/review", json=data)
         return CogniacOpsReview(connection, resp.json())
 
     ##
@@ -72,7 +72,7 @@ class CogniacOpsReview(object):
             review_items
             review_unit if any
         """
-        resp = connection._get("/ops/review")
+        resp = connection._get("/1/ops/review")
         return CogniacOpsReview(connection, resp.json())
 
     ##
@@ -86,7 +86,7 @@ class CogniacOpsReview(object):
         return number of pending items in operations review queue
         connnection (CogniacConnection): Authenticated CogniacConnection object
         """
-        resp = connection._get("/ops/review/pending")
+        resp = connection._get("/1/ops/review/pending")
         return resp.json()['pending']
 
     ##
@@ -110,7 +110,7 @@ class CogniacOpsReview(object):
         data = dict(review_id=review_id, result=result)
         if comment:
             data['comment'] = comment
-        resp = connection._post("/ops/results", json=data)
+        resp = connection._post("/1/ops/results", json=data)
         return CogniacOpsReview(connection, resp.json())
 
     ##
@@ -161,7 +161,7 @@ class CogniacOpsReview(object):
             args.append("review_unit=%s" % review_unit)
         if result is not None:
             args.append("result=%s" % result)
-        url = "/ops/results?"
+        url = "/1/ops/results?"
         url += "&".join(args)
 
         @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
@@ -202,7 +202,7 @@ class CogniacOpsReview(object):
         """
         Delete the op review result.
         """
-        resp = self._cc._delete("/ops/review/%s" % self.review_id)
+        resp = self._cc._delete("/1/ops/review/%s" % self.review_id)
 
         for k in self._sub_keys:
             delattr(self, k)

--- a/cogniac/subject.py
+++ b/cogniac/subject.py
@@ -70,7 +70,7 @@ class CogniacSubject(object):
         if external_id:
             data['external_id'] = external_id
 
-        resp = connection._post("/subjects", json=data)
+        resp = connection._post("/1/subjects", json=data)
 
         return CogniacSubject(connection, resp.json())
 
@@ -88,7 +88,7 @@ class CogniacSubject(object):
         connnection (CogniacConnection):     Authenticated CogniacConnection object
         subject_id (String):                 The subject_id of the Cogniac Subject to return
         """
-        resp = connection._get("/subjects/%s" % subject_uid)
+        resp = connection._get("/1/subjects/%s" % subject_uid)
         return CogniacSubject(connection, resp.json())
 
     ##
@@ -110,7 +110,7 @@ class CogniacSubject(object):
         if public_write:
             args.append("public_read_write=True")
 
-        url = "/tenants/%s/subjects?" % connection.tenant.tenant_id
+        url = "/1/tenants/%s/subjects?" % connection.tenant.tenant_id
         url += "&".join(args)
 
         resp = connection._get(url)
@@ -164,7 +164,7 @@ class CogniacSubject(object):
         elif name:
             args.append('name=%s' % name)
 
-        url = "/tenants/%s/subjects?" % connection.tenant.tenant_id
+        url = "/1/tenants/%s/subjects?" % connection.tenant.tenant_id
         url += "&".join(args)
 
         resp = connection._get(url)
@@ -195,7 +195,7 @@ class CogniacSubject(object):
         """
         Delete the subject.
         """
-        resp = self._cc._delete("/subjects/%s" % self.subject_uid)
+        resp = self._cc._delete("/1/subjects/%s" % self.subject_uid)
 
         for k in self._sub_keys:
             delattr(self, k)
@@ -207,7 +207,7 @@ class CogniacSubject(object):
             raise AttributeError("%s is immutable" % name)
         if name in ['name', 'description', 'expires_in', 'external_id', 'custom_data']:
             data = {name: value}
-            resp = self._cc._post("/subjects/%s" % self.subject_uid, json=data)
+            resp = self._cc._post("/1/subjects/%s" % self.subject_uid, json=data)
             for k, v in resp.json().items():
                 super(CogniacSubject, self).__setattr__(k, v)
             return
@@ -321,7 +321,7 @@ class CogniacSubject(object):
             else:
                 files = {'file': open(filename, 'rb')}
                 # api.add_resource(SubjectReferenceMedia, '/1/subjects/<string:subject_uid>/referenceMedia')
-            resp = self._cc._post("/subjects/{}/referenceMedia".format(self.subject_uid), data=args, files=files)
+            resp = self._cc._post("/1/subjects/{}/referenceMedia".format(self.subject_uid), data=args, files=files)
             return resp
 
         resp = upload()
@@ -350,7 +350,7 @@ class CogniacSubject(object):
 
         if focus is not None:
             data['focus'] = focus
-        self._cc._delete("/subjects/%s/media" % self.subject_uid, json=data)
+        self._cc._delete("/1/subjects/%s/media" % self.subject_uid, json=data)
 
     ##
     #  associate_media
@@ -416,7 +416,7 @@ class CogniacSubject(object):
         data['app_data_type'] = app_data_type
         data['app_data'] = app_data
 
-        resp = self._cc._post("/subjects/%s/media" % self.subject_uid, json=data)
+        resp = self._cc._post("/1/subjects/%s/media" % self.subject_uid, json=data)
         return resp.json()['capture_id']
 
     ##
@@ -483,7 +483,7 @@ class CogniacSubject(object):
         if abridged_media:
             args.append('abridged_media=True')
 
-        url = "/subjects/%s/media?" % self.subject_uid
+        url = "/1/subjects/%s/media?" % self.subject_uid
         url += "&".join(args)
 
         @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)

--- a/cogniac/tenant.py
+++ b/cogniac/tenant.py
@@ -26,7 +26,7 @@ class CogniacTenant(object):
     @classmethod
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
     def get(cls, connection):
-        resp = connection._get("/tenants/current")
+        resp = connection._get("/1/tenants/current")
         return CogniacTenant(connection, json.loads(resp.content))
 
     def __init__(self, connection, tenant_dict):
@@ -46,12 +46,12 @@ class CogniacTenant(object):
             super(CogniacTenant, self).__setattr__(name, value)
             return
         data = {name: value}
-        resp = self._cc._post("/tenants/%s" % self.tenant_id, json=data)
+        resp = self._cc._post("/1/tenants/%s" % self.tenant_id, json=data)
         for k, v in resp.json().items():
             super(CogniacTenant, self).__setattr__(k, v)
 
     def users(self):
-        resp = self._cc._get("/tenants/%s/users" % self.tenant_id)
+        resp = self._cc._get("/1/tenants/%s/users" % self.tenant_id)
         return resp.json()['data']
 
     def set_user_role(self, user_email, role):
@@ -60,7 +60,7 @@ class CogniacTenant(object):
         if not users:
             raise Exception("unknown user_email %s" % user_email)
         data = {'user_id': users[0]['user_id'], 'role': role}
-        self._cc._post("/tenants/%s/users/role" % self.tenant_id, json=data)
+        self._cc._post("/1/tenants/%s/users/role" % self.tenant_id, json=data)
 
     def add_user(self, user_email, role='tenant_user'):
         users = self.users()
@@ -68,7 +68,7 @@ class CogniacTenant(object):
         if not users:
             raise Exception("unknown user_email %s" % user_email)
         data = {'user_id': users[0]['user_id'], 'role': role}
-        self._cc._post("/tenants/%s/users" % self.tenant_id, json=data)
+        self._cc._post("/1/tenants/%s/users" % self.tenant_id, json=data)
 
     def delete_user(self, user_email):
         users = self.users()
@@ -76,13 +76,13 @@ class CogniacTenant(object):
         if not users:
             raise Exception("unknown user_email %s" % user_email)
         data = {'user_id': users[0]['user_id']}
-        self._cc._delete("/tenants/%s/users" % self.tenant_id, json=data)
+        self._cc._delete("/1/tenants/%s/users" % self.tenant_id, json=data)
 
     def usage(self, start, end, period='15min'):
 
         assert(period in ['15min', 'hour', 'day'])
 
-        url = "/usage/summary?period=%s&start=%d&end=%d" % (period, start, end)
+        url = "/1/usage/summary?period=%s&start=%d&end=%d" % (period, start, end)
 
         @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
         def get_next(url):

--- a/cogniac/user.py
+++ b/cogniac/user.py
@@ -21,7 +21,7 @@ class CogniacUser(object):
     @classmethod
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
     def get(cls, connection):
-        resp = connection._get("/users/current")
+        resp = connection._get("/1/users/current")
         return CogniacUser(connection, json.loads(resp.content))
 
     def __init__(self, connection, tenant_dict):
@@ -38,23 +38,23 @@ class CogniacUser(object):
     def __setattr__(self, name, value):
         if name in mutable_keys:
             data = {name: value}
-            resp = self._cc._post("/users/%s" % self.user_id, json=data)
+            resp = self._cc._post("/1/users/%s" % self.user_id, json=data)
             for k, v in resp.json().items():
                 super(CogniacUser, self).__setattr__(k, v)
             return
         super(CogniacUser, self).__setattr__(name, value)
 
     def api_keys(self):
-        resp = self._cc._get("/users/%s/apiKeys" % self.user_id)
+        resp = self._cc._get("/1/users/%s/apiKeys" % self.user_id)
         return resp.json()['data']
 
     def api_key(self, key_id):
-        resp = self._cc._get("/users/%s/apiKeys/%s" % (self.user_id, key_id))
+        resp = self._cc._get("/1/users/%s/apiKeys/%s" % (self.user_id, key_id))
         return resp.json()
 
     def create_api_key(self, description):
-        resp = self._cc._post("/users/%s/apiKeys" % self.user_id, json={'description': description})
+        resp = self._cc._post("/1/users/%s/apiKeys" % self.user_id, json={'description': description})
         return resp.json()
 
     def delete_api_key(self, key_id):
-        self._cc._delete("/users/%s/apiKeys/%s" % (self.user_id, key_id))
+        self._cc._delete("/1/users/%s/apiKeys/%s" % (self.user_id, key_id))


### PR DESCRIPTION
The intent here is to enable per-endpoint API versioning so service APIs can be introduced incrementally (e.g., pending services with API version `/21/`).

No endpoints were introduced with new versions. This PR just places the version for APIs in endpoint calls.

These changes are being made such that the `COG_URL_PREFIX` environment variable no longer requires the API version in the string. For example, where the API base URL and version were previously set (e.g., `export COG_URL_PREFIX=https://api.cogniac.io/1/`), now only the base API URL would need to be set (e.g., `export COG_URL_PREFIX=https://api.cogniac.io/`). The SDK will detect if the version is specified and strip it from the `COG_URL_PREFIX` if present.

If `COG_URL_PREFIX` includes the version, it will be stripped.

### Summary of changes

- [x] Added endpoint version for following occurrences:
    - [x] `requests.get`, `requests.post`, `requests.delete`
    - [x] `_get(`
    - [x] `_post(`
    - [x] `_delete(`
    - [x] `"url ="`
- [x] test SDK with `COG_URL_PREFIX=https://api.cogniac.io/1` (backward compatibility)
- [x] test SDK  with `COG_URL_PREFIX=https://api.cogniac.io/1/` (backward compatibility)
- [x] test SDK  with `COG_URL_PREFIX=https://api.cogniac.io`
- [x] test SDK  with `COG_URL_PREFIX=https://api.cogniac.io/`