### PR TITLE
Update endpoints that require updates to support Feedback Service API v21.

### DIFF
--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -330,12 +330,12 @@ class CogniacApplication(object):
     #  count_feedback_requests (v21)
     ##
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
-    def count_feedback_requests(self):
+    def count_feedback_requests(self, limit=100):
         """
         Return the integer number of feedback requests available to the user 
         for this application.
         """
-        resp = self._cc._get("/21/applications/%s/feedbackRequests/count" % (self.application_id, limit))
+        resp = self._cc._get("/21/applications/%s/feedbackRequests/count?limit=%d" % (self.application_id, limit))
         return resp.json()['count']
 
     ##
@@ -365,7 +365,7 @@ class CogniacApplication(object):
 
                 result (str):
                     Type of subject-media association ('True', 'False', 
-                    'Sidelined', or 'Uncertain').
+                    'Sidelined').
 
                 app_data_type (str):
                     (Optional) Type of extra app-specific data for certain 
@@ -375,12 +375,13 @@ class CogniacApplication(object):
                     (Optional) Additional, app-specific, subject-media 
                     association data.
         """
+        assert(feedback_request_id is not None or media_id is not None)
         feedback_response = {
             'feedback_request_id': feedback_request_id,
             'media_id': media_id,
             'subjects': subjects
         }
-        response = self._cc._post("/21/applications/%s/feedbackRequests/%s/feedbackResponses" % (self.application_id, feedback_request_id), json=feedback_response)
+        response = self._cc._post("/21/applications/%s/feedback" % (self.application_id), json=feedback_response)
         return response.json()['subjects']
     
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -248,7 +248,6 @@ class CogniacApplication(object):
 
             Defaults to 1.
         """
-<<<<<<< HEAD
         # add media_id to each subject-media association dict
         # TODO: deprecate this
         for s in subjects:
@@ -261,25 +260,18 @@ class CogniacApplication(object):
 
     # <TODO>
     # TODO: count_feedback_requests
-    # ##
-    # #  pending_feedback
-    # ##
-    # @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
-    # def pending_feedback(self):
-    #     """
-    #     Return the integer number of feedback requests pending for this application.
-    #     This is useful for controlling the flow of images input into the system to avoid creating too many backlogged feedback requests.
-    #     """
-    #     resp = self._cc._get("/21/applications/%s/feedback/pending" % self.application_id)
-    #     return resp.json()['pending']
-    # </TODO>
-=======
+    ##
+    #  pending_feedback
+    ##
+    @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
+    def pending_feedback(self):
+        """
         Return the integer number of feedback requests pending for this application.
         This is useful for controlling the flow of images input into the system to avoid creating too many backlogged feedback requests.
         """
         resp = self._cc._get("/1/applications/%s/feedback/pending" % self.application_id)
         return resp.json()['pending']
->>>>>>> master
+    # </TODO>
 
     ##
     #  get_feedback_requests
@@ -291,11 +283,7 @@ class CogniacApplication(object):
 
         limit (Int):   Maximum number of feedback request messages to return
         """
-<<<<<<< HEAD
         resp = self._cc._get("/21/applications/%s/feedbackRequests?limit=%d" % (self.application_id, limit))
-=======
-        resp = self._cc._get("/1/applications/%s/feedback?limit=%d" % (self.application_id, limit))
->>>>>>> master
         return resp.json()
 
     ##
@@ -319,12 +307,8 @@ class CogniacApplication(object):
         feedback_response = {'media_id': media_id,
                              'subjects': subjects}
 
-<<<<<<< HEAD
         self._cc._post("/21/applications/%s/feedbackRequests/%s/feedbackResponses" % (self.application_id, feedback_request_id),
                        json=feedback_response)
-=======
-        self._cc._post("/1/applications/%s/feedback" % self.application_id, json=feedback_response)
->>>>>>> master
 
     ##
     #  list of models released

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -334,6 +334,10 @@ class CogniacApplication(object):
         """
         Return the integer number of feedback requests available to the user 
         for this application.
+
+        Arguments:
+
+            limit (int): Maximum number of feedback requests to return.
         """
         resp = self._cc._get("/21/applications/%s/feedbackRequests/count?limit=%d" % (self.application_id, limit))
         return resp.json()['count']

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -324,7 +324,7 @@ class CogniacApplication(object):
         limit (int): Maximum number of feedback requests to return.
         """
         resp = self._cc._get("/21/applications/%s/feedbackRequests?limit=%d" % (self.application_id, limit))
-        return resp.json()
+        return resp.json()['data']
 
     ##
     #  count_feedback_requests (v21)

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -376,7 +376,7 @@ class CogniacApplication(object):
             'subjects': subjects
         }
         response = self._cc._post("/21/applications/%s/feedbackRequests/%s/feedbackResponses" % (self.application_id, feedback_request_id), json=feedback_response)
-        return response['subjects']
+        return response.json()['subjects']
 
     ##
     #  list of models released

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -384,6 +384,18 @@ class CogniacApplication(object):
         return response.json()['subjects']
     
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
+    def delete_feedback_request(self, feedback_request_id):
+        """Delete a specific feedback request for the application.
+
+        Arguments:
+
+            feedback_request_id (str):
+                Unique feedback request identifier for which feedback is being 
+                submitted.
+        """
+        self._cc._delete("/21/applications/%s/feedbackRequests/%s" % self.application_id, feedback_request_id)
+    
+    @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
     def purge_feedback_requests(self):
         """Delete the application's feedback requests.
         """

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -382,6 +382,12 @@ class CogniacApplication(object):
         }
         response = self._cc._post("/21/applications/%s/feedbackRequests/%s/feedbackResponses" % (self.application_id, feedback_request_id), json=feedback_response)
         return response.json()['subjects']
+    
+    @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
+    def purge_feedback_requests(self):
+        """Delete the application's feedback requests.
+        """
+        self._cc._delete("/21/applications/%s/feedbackRequests" % self.application_id)
 
     ##
     #  list of models released

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -251,11 +251,11 @@ class CogniacApplication(object):
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
     def request_feedback(self,
                          media_id,
-                         subjects,
+                         subjects=None,
                          focus=None,
                          total_response_count_min=1,
                          per_reviewer_response_count_max=1,
-                         reviewer_roles=None):
+                         reviewer_roles=['anyone']):
         """
         Requests application feedback on the specified media.
 
@@ -306,10 +306,6 @@ class CogniacApplication(object):
 
             Defaults to 1.
         """
-        # add media_id to each subject-media association dict
-        for s in subjects:
-            s['media_id'] = media_id
-
         feedback_request = {'media_id': media_id,
                             'subjects': subjects,
                             'per_reviewer_response_count_max': per_reviewer_response_count_max,
@@ -348,7 +344,7 @@ class CogniacApplication(object):
     #  submit_feedback (v21)
     ##
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
-    def submit_feedback(self, feedback_request_id, subjects):
+    def submit_feedback(self, subjects, feedback_request_id=None, media_id=None):
         """
         Submits feedback containing subject-media assertions in response to a
         specified feedback request for this application.
@@ -383,6 +379,7 @@ class CogniacApplication(object):
         """
         feedback_response = {
             'feedback_request_id': feedback_request_id,
+            'media_id': media_id,
             'subjects': subjects
         }
         response = self._cc._post("/21/applications/%s/feedbackRequests/%s/feedbackResponses" % (self.application_id, feedback_request_id), json=feedback_response)

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -192,6 +192,31 @@ class CogniacApplication(object):
         subject (CogniacSubject):   the subject to add
         """
         self.input_subjects = self.input_subjects + [subject.subject_uid]
+    
+    ##
+    #  pending_feedback (legacy)
+    ##
+    @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
+    def pending_feedback(self):
+        """
+        Return the integer number of feedback requests pending for this application.
+        This is useful for controlling the flow of images input into the system to avoid creating too many backlogged feedback requests.
+        """
+        resp = self._cc._get("/1/applications/%s/feedback/pending" % self.application_id)
+        return resp.json()['pending']
+
+    ##
+    #  get_feedback (legacy)
+    ##
+    @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
+    def get_feedback(self, limit=10):
+        """
+        returns a list of  up to {limit} feedback request messages for the application
+
+        limit (Int):   Maximum number of feedback request messages to return
+        """
+        resp = self._cc._get("/1/applications/%s/feedback?limit=%d" % (self.application_id, limit))
+        return resp.json()
 
     ##
     #  request_feedback
@@ -249,7 +274,6 @@ class CogniacApplication(object):
             Defaults to 1.
         """
         # add media_id to each subject-media association dict
-        # TODO: deprecate this
         for s in subjects:
             s['media_id'] = media_id
 
@@ -257,21 +281,6 @@ class CogniacApplication(object):
                              'subjects': subjects}
 
         self._cc._post("/21/applications/%s/feedbackRequests" % self.application_id, json=feedback_response)
-
-    # <TODO>
-    # TODO: count_feedback_requests
-    ##
-    #  pending_feedback
-    ##
-    @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
-    def pending_feedback(self):
-        """
-        Return the integer number of feedback requests pending for this application.
-        This is useful for controlling the flow of images input into the system to avoid creating too many backlogged feedback requests.
-        """
-        resp = self._cc._get("/1/applications/%s/feedback/pending" % self.application_id)
-        return resp.json()['pending']
-    # </TODO>
 
     ##
     #  get_feedback_requests
@@ -284,6 +293,19 @@ class CogniacApplication(object):
         limit (Int):   Maximum number of feedback request messages to return
         """
         resp = self._cc._get("/21/applications/%s/feedbackRequests?limit=%d" % (self.application_id, limit))
+        return resp.json()
+
+    ##
+    #  get_feedback_requests
+    ##
+    @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
+    def count_feedback_requests(self, limit=10):
+        """
+        returns a list of  up to {limit} feedback request messages for the application
+
+        limit (Int):   Maximum number of feedback request messages to return
+        """
+        resp = self._cc._get("/21/applications/%s/feedbackRequests/count" % (self.application_id, limit))
         return resp.json()
 
     ##

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -164,7 +164,7 @@ class CogniacApplication(object):
         if name in ['name', 'description', 'active', 'input_subjects', 'output_subjects', 'app_managers',
                     'detection_post_urls', 'detection_thresholds', 'custom_fields', 'app_type_config',
                     'edgeflow_upload_policies', 'override_upstream_detection_filter', 'feedback_resample_ratio',
-                    'reviewers', 'inference_execution_policies', 'primary_release_metric', 'secondary_evaluation_metrics']:
+                    'inference_execution_policies', 'primary_release_metric', 'secondary_evaluation_metrics']:
             data = {name: value}
             self.__post_update__(data)
             return
@@ -255,7 +255,7 @@ class CogniacApplication(object):
                          focus=None,
                          total_response_count_min=1,
                          per_reviewer_response_count_max=1,
-                         reviewer_roles=['anyone']):
+                         roles=['anyone']):
         """
         Requests application feedback on the specified media.
 
@@ -284,18 +284,16 @@ class CogniacApplication(object):
             Defaults to `None`, indicating feedback can be provided in any region
             of the specified media item.
 
-        reviewer_roles (list):
-            List of application reviewer roles required by application reviewers
-            to receive this feedback request and that will be allowed to provide
-            feedback in response to this feedback request.
+        roles (list):
+            List of annotator roles for which the feedback request will be 
+            available.
                                        
-            The available roles are limited to those assignable to users added
-            as application reviewers (in an application's `reviewers` field),
-            including "annotator" and "reviewer".
+            Supported annotator roles are `"anyone"`, `"annotator"`, and
+            `"expert_annotator"`.
                                        
         total_response_count_min (int):
             (Optional) The total number of feedback responses required to 
-            fulfill this feedback request.o
+            fulfill this feedback request.
                                         
             Defaults to 1.
 
@@ -311,7 +309,7 @@ class CogniacApplication(object):
                             'per_reviewer_response_count_max': per_reviewer_response_count_max,
                             'total_response_count_min': total_response_count_min,
                             'focus': focus,
-                            'reviewer_roles': reviewer_roles}
+                            'roles': roles}
 
         self._cc._post("/21/applications/%s/feedbackRequests" % self.application_id, json=feedback_request)
 

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -202,7 +202,7 @@ class CogniacApplication(object):
         Return the integer number of feedback requests pending for this application.
         This is useful for controlling the flow of images input into the system to avoid creating too many backlogged feedback requests.
         """
-        resp = self._cc._get("/applications/%s/feedback/pending" % self.application_id)
+        resp = self._cc._get("/21/applications/%s/feedback/pending" % self.application_id)
         return resp.json()['pending']
 
     ##
@@ -215,7 +215,7 @@ class CogniacApplication(object):
 
         limit (Int):   Maximum number of feedback request messages to return
         """
-        resp = self._cc._get("/applications/%s/feedback?limit=%d" % (self.application_id, limit))
+        resp = self._cc._get("/21/applications/%s/feedback?limit=%d" % (self.application_id, limit))
         return resp.json()
 
     ##
@@ -243,7 +243,7 @@ class CogniacApplication(object):
         feedback_response = {'media_id': media_id,
                              'subjects': subjects}
 
-        self._cc._post("/applications/%s/feedback" % self.application_id, json=feedback_response)
+        self._cc._post("/21/applications/%s/feedback" % self.application_id, json=feedback_response)
 
     ##
     #  list of models released

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -396,8 +396,8 @@ class CogniacApplication(object):
         self._cc._delete("/21/applications/%s/feedbackRequests/%s" % self.application_id, feedback_request_id)
     
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
-    def purge_feedback_requests(self):
-        """Delete the application's feedback requests.
+    def delete_feedback_requests(self):
+        """Delete all feedback requests for the application.
         """
         self._cc._delete("/21/applications/%s/feedbackRequests" % self.application_id)
 

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -249,7 +249,13 @@ class CogniacApplication(object):
     #  request_feedback (v21)
     ##
     @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
-    def request_feedback(self, media_id, subjects):
+    def request_feedback(self,
+                         media_id,
+                         subjects,
+                         focus=None,
+                         total_response_count_min=1,
+                         per_reviewer_response_count_max=1,
+                         reviewer_roles=None):
         """
         Requests application feedback on the specified media.
 
@@ -304,10 +310,14 @@ class CogniacApplication(object):
         for s in subjects:
             s['media_id'] = media_id
 
-        feedback_response = {'media_id': media_id,
-                             'subjects': subjects}
+        feedback_request = {'media_id': media_id,
+                            'subjects': subjects,
+                            'per_reviewer_response_count_max': per_reviewer_response_count_max,
+                            'total_response_count_min': total_response_count_min,
+                            'focus': focus,
+                            'reviewer_roles': reviewer_roles}
 
-        self._cc._post("/21/applications/%s/feedbackRequests" % self.application_id, json=feedback_response)
+        self._cc._post("/21/applications/%s/feedbackRequests" % self.application_id, json=feedback_request)
 
     ##
     #  get_feedback_requests (v21)

--- a/cogniac/tenant.py
+++ b/cogniac/tenant.py
@@ -94,3 +94,19 @@ class CogniacTenant(object):
             for record in resp['data']:
                 yield record
             url = resp['paging'].get('next')
+
+    ##
+    #  count_feedback_requests (v21)
+    ##
+    @retry(stop_max_attempt_number=8, wait_exponential_multiplier=500, retry_on_exception=server_error)
+    def count_feedback_requests(self, limit=100):
+        """
+        Return the integer number of feedback requests available to the user 
+        for across all applications in the tenant.
+        
+        Arguments:
+
+            limit (int): Maximum number of feedback requests to return.
+        """
+        resp = self._cc._get("/21/tenants/%s/feedbackRequests/count?limit=%d" % (self.tenant_id, limit))
+        return resp.json()['count']

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='cogniac',
-      version='2.0.7',
+      version='2.0.8',
       description='Python SDK for Cogniac Public API',
       packages=['cogniac'],
       author = 'Cogniac Corporation',


### PR DESCRIPTION
Resolves https://github.com/Cogniac/cogniac-sdk-py/issues/101.

### Changes
- Adds SDK support for the feedback service API v21 endpoints.

### Notes
- To retain compatibility with existing clients using the SDK, functions using the feedback service API v1 endpoints are unchanged. The idea is that we can continue deprecating the v1 service on the backend by rerouting the corresponding HTTP paths to the v21 endpoints or call the v21 endpoints from the old paths.