### PR TITLE
Support cloudflow

### DIFF
--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -255,6 +255,7 @@ class CogniacConnection(object):
         """
         wrap requests session to re-authenticate on credential expiration
         """
+        print("^^^ url: {}  ^^^".format(url))
         if not url.startswith("http"):
             # Prepend /1/ version if no version is specified in the URL (backward compatibility).
             m = re.search(r'^/\d+(/)?', url)
@@ -503,7 +504,7 @@ class CogniacConnection(object):
 
     def get_edgeflow(self, edgeflow_id):
         """
-        return an existing CogniacEdgeFlow 
+        return an existing CogniacEdgeFlow
 
         edgeflow_id (String):  The id of the Cogniac EdgeFlow to return
         """

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -168,7 +168,6 @@ class CogniacEdgeFlow(object):
             url = self.url_prefix + url
         if timeout is None:
             timeout = self.timeout
-        print("_post: url: {}".format(url))
         resp = self.session.post(url, timeout=timeout, **kwargs)
         raise_errors(resp)
         return resp

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -16,7 +16,6 @@ from requests.adapters import HTTPAdapter
 from .common import server_error, raise_errors
 from .media import file_creation_time
 
-from pprint import pprint
 
 IP_REGEX = re.compile('^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$')
 


### PR DESCRIPTION
Address support for cloudflow /1/process calls.
The following will now work for cloudflow and local (on-prem) edgeflow systems.
```
ef = cc.get_edgeflow('xxxx').  # xxx is the edgeflow_id or cloudflow_id
ef.process_media(subject_uid, media_filename)
```
