### PR TITLE
Rename `cog` CLI command to `cogniac`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,36 +60,36 @@ URLs are version-prefixed (e.g., `/1/tenants`, `/21/users/current`). `CogniacCon
 
 `cogniac/__init__.py` re-exports all public classes. New entity classes must be added there to be importable as `from cogniac import ClassName`.
 
-## `cog` CLI Tool
+## `cogniac` CLI Tool
 
 Agent-friendly CLI. JSON output by default, `--format table` for human-readable. Auth via env vars (`COG_USER`/`COG_PASS` or `COG_API_KEY`, plus `COG_TENANT`).
 
 Read commands:
 ```
-cog auth                    # check credentials and connectivity
-cog tenant                  # current tenant info
-cog tenants                 # list all authorized tenants (no COG_TENANT needed)
-cog apps list               # list all applications
-cog apps get <id>           # get specific application
-cog subjects list           # list all subjects
-cog subjects get <uid>      # get specific subject
-cog subjects search         # search: --prefix, --similar, --name, --ids, --limit
-cog subjects media <uid>    # list media associations: --limit, --consensus, --probability-lower/upper
-cog media get <id>          # get specific media
-cog media search            # search: --md5, --filename, --external-media-id, --domain-unit, --limit
-cog edgeflows list          # list all edgeflows
-cog edgeflows get <id>      # get specific edgeflow
-cog edgeflows status <id>   # status events: --subsystem, --limit
-cog cameras list            # list all cameras
-cog cameras get <id>        # get specific camera
-cog version                 # API version info
+cogniac auth                    # check credentials and connectivity
+cogniac tenant                  # current tenant info
+cogniac tenants                 # list all authorized tenants (no COG_TENANT needed)
+cogniac apps list               # list all applications
+cogniac apps get <id>           # get specific application
+cogniac subjects list           # list all subjects
+cogniac subjects get <uid>      # get specific subject
+cogniac subjects search         # search: --prefix, --similar, --name, --ids, --limit
+cogniac subjects media <uid>    # list media associations: --limit, --consensus, --probability-lower/upper
+cogniac media get <id>          # get specific media
+cogniac media search            # search: --md5, --filename, --external-media-id, --domain-unit, --limit
+cogniac edgeflows list          # list all edgeflows
+cogniac edgeflows get <id>      # get specific edgeflow
+cogniac edgeflows status <id>   # status events: --subsystem, --limit
+cogniac cameras list            # list all cameras
+cogniac cameras get <id>        # get specific camera
+cogniac version                 # API version info
 ```
 
 Write commands:
 ```
-cog subjects create <name>              # --description, --external-id
-cog subjects associate <uid> <media_id> # --consensus (True/False/Sidelined/None)
-cog media upload <filename>             # --subject-uid, --external-media-id, --domain-unit, --meta-tags
+cogniac subjects create <name>              # --description, --external-id
+cogniac subjects associate <uid> <media_id> # --consensus (True/False/Sidelined/None)
+cogniac media upload <filename>             # --subject-uid, --external-media-id, --domain-unit, --meta-tags
 ```
 
 Implementation is in `cogniac/cli.py`. Entry point registered in `setup.py` via `console_scripts`.

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -4,31 +4,31 @@ Cogniac CLI - Agent-friendly command-line interface to the Cogniac API.
 Outputs JSON (default) or table format. Errors are JSON on stderr.
 
 Read commands:
-    cog tenant
-    cog tenants
-    cog apps list
-    cog apps get <application_id>
-    cog subjects list
-    cog subjects get <subject_uid>
-    cog subjects search [--prefix P] [--name N] [--similar S] [--ids ID ...] [--limit L]
-    cog subjects media <subject_uid> [--limit L] [--consensus C] [--probability-lower P] [--probability-upper P]
-    cog media get <media_id>
-    cog media search [--md5 M] [--filename F] [--external-media-id E] [--domain-unit D] [--limit L]
-    cog edgeflows list
-    cog edgeflows get <edgeflow_id>
-    cog edgeflows status <edgeflow_id> [--subsystem S] [--limit L]
-    cog cameras list
-    cog cameras get <network_camera_id>
-    cog deployments list
-    cog deployments get <deployment_group_id>
-    cog workflows get <workflow_id>
-    cog version
-    cog auth
+    cogniac tenant
+    cogniac tenants
+    cogniac apps list
+    cogniac apps get <application_id>
+    cogniac subjects list
+    cogniac subjects get <subject_uid>
+    cogniac subjects search [--prefix P] [--name N] [--similar S] [--ids ID ...] [--limit L]
+    cogniac subjects media <subject_uid> [--limit L] [--consensus C] [--probability-lower P] [--probability-upper P]
+    cogniac media get <media_id>
+    cogniac media search [--md5 M] [--filename F] [--external-media-id E] [--domain-unit D] [--limit L]
+    cogniac edgeflows list
+    cogniac edgeflows get <edgeflow_id>
+    cogniac edgeflows status <edgeflow_id> [--subsystem S] [--limit L]
+    cogniac cameras list
+    cogniac cameras get <network_camera_id>
+    cogniac deployments list
+    cogniac deployments get <deployment_group_id>
+    cogniac workflows get <workflow_id>
+    cogniac version
+    cogniac auth
 
 Write commands:
-    cog subjects create <name> [--description D] [--external-id E]
-    cog subjects associate <subject_uid> <media_id> [--consensus C]
-    cog media upload <filename> [--subject-uid S] [--external-media-id E] [--domain-unit D] [--meta-tags T ...]
+    cogniac subjects create <name> [--description D] [--external-id E]
+    cogniac subjects associate <subject_uid> <media_id> [--consensus C]
+    cogniac media upload <filename> [--subject-uid S] [--external-media-id E] [--domain-unit D] [--meta-tags T ...]
 
 Global options:
     --format json|table  (default: json)
@@ -423,26 +423,26 @@ def cmd_media_upload(args):
 
 def build_parser():
     parser = argparse.ArgumentParser(
-        prog='cog',
+        prog='cogniac',
         description='Cogniac CLI - query and manage the Cogniac API (JSON or table output)',
     )
     parser.add_argument('--format', choices=['json', 'table'], default='json',
                         help='Output format (default: json)')
     subparsers = parser.add_subparsers(dest='command')
 
-    # cog tenant
+    # cogniac tenant
     p = subparsers.add_parser('tenant', help='Show current tenant info')
     p.set_defaults(func=cmd_tenant)
 
-    # cog tenants
+    # cogniac tenants
     p = subparsers.add_parser('tenants', help='List all authorized tenants')
     p.set_defaults(func=cmd_tenants)
 
-    # cog version
+    # cogniac version
     p = subparsers.add_parser('version', help='Show API version info')
     p.set_defaults(func=cmd_version)
 
-    # cog apps
+    # cogniac apps
     apps_parser = subparsers.add_parser('apps', help='Applications')
     apps_sub = apps_parser.add_subparsers(dest='apps_command')
 
@@ -453,7 +453,7 @@ def build_parser():
     p.add_argument('application_id', help='Application ID')
     p.set_defaults(func=cmd_apps_get)
 
-    # cog subjects
+    # cogniac subjects
     subjects_parser = subparsers.add_parser('subjects', help='Subjects')
     subjects_sub = subjects_parser.add_subparsers(dest='subjects_command')
 
@@ -494,7 +494,7 @@ def build_parser():
                    help='Consensus label (default: None)')
     p.set_defaults(func=cmd_subjects_associate)
 
-    # cog media
+    # cogniac media
     media_parser = subparsers.add_parser('media', help='Media')
     media_sub = media_parser.add_subparsers(dest='media_command')
 
@@ -518,7 +518,7 @@ def build_parser():
     p.add_argument('--meta-tags', dest='meta_tags', nargs='+', help='Metadata tags')
     p.set_defaults(func=cmd_media_upload)
 
-    # cog edgeflows
+    # cogniac edgeflows
     ef_parser = subparsers.add_parser('edgeflows', help='EdgeFlow devices')
     ef_sub = ef_parser.add_subparsers(dest='edgeflows_command')
 
@@ -535,7 +535,7 @@ def build_parser():
     p.add_argument('--limit', type=int, default=10, help='Max results (default: 10)')
     p.set_defaults(func=cmd_edgeflows_status)
 
-    # cog cameras
+    # cogniac cameras
     cam_parser = subparsers.add_parser('cameras', help='Network cameras')
     cam_sub = cam_parser.add_subparsers(dest='cameras_command')
 
@@ -546,7 +546,7 @@ def build_parser():
     p.add_argument('network_camera_id', help='Network camera ID')
     p.set_defaults(func=cmd_cameras_get)
 
-    # cog deployments
+    # cogniac deployments
     dep_parser = subparsers.add_parser('deployments', help='Deployment groups')
     dep_sub = dep_parser.add_subparsers(dest='deployments_command')
 
@@ -557,7 +557,7 @@ def build_parser():
     p.add_argument('deployment_group_id', help='Deployment group ID')
     p.set_defaults(func=cmd_deployments_get)
 
-    # cog workflows
+    # cogniac workflows
     wf_parser = subparsers.add_parser('workflows', help='Workflows')
     wf_sub = wf_parser.add_subparsers(dest='workflows_command')
 
@@ -565,11 +565,11 @@ def build_parser():
     p.add_argument('workflow_id', help='Workflow ID')
     p.set_defaults(func=cmd_workflows_get)
 
-    # cog auth
+    # cogniac auth
     p = subparsers.add_parser('auth', help='Check credentials and connectivity')
     p.set_defaults(func=cmd_auth)
 
-    # cog user
+    # cogniac user
     p = subparsers.add_parser('user', help='Show current user info and system roles')
     p.set_defaults(func=cmd_user)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='cogniac',
       scripts=['bin/icogniac', 'bin/cogupload', 'bin/cogstats'],
       entry_points={
           'console_scripts': [
-              'cog=cogniac.cli:main',
+              'cogniac=cogniac.cli:main',
           ],
       },
       install_requires=['requests', 'retrying', 'tabulate', 'six'])


### PR DESCRIPTION
## Summary
- Renames the CLI entry point from `cog` to `cogniac` based on team discussion (2026-04-02) about using "cogniac" consistently in naming for discoverability and to make it easy to find Cogniac tools
- The CLI is still new, so this is a good time to make this change before usage is widespread
- Updates `setup.py` console_scripts, argparse `prog` name, all docstring/comment references in `cli.py`, and `CLAUDE.md` documentation

## Test plan
- [ ] `pip install -e .` and verify `cogniac --help` works
- [ ] Verify `cogniac tenant`, `cogniac apps list`, etc. function correctly
- [ ] Confirm old `cog` command is no longer registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)