### PR TITLE
Add subject_weights as a mutable application field

### DIFF
--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -167,9 +167,10 @@ class CogniacApplication(object):
             raise AttributeError("%s is immutable" % name)
 
         if name in ['name', 'description', 'active', 'input_subjects', 'output_subjects', 'app_managers',
-                    'detection_post_urls', 'detection_thresholds', 'custom_fields', 'app_type_config',
-                    'edgeflow_upload_policies', 'override_upstream_detection_filter', 'feedback_resample_ratio',
-                    'reviewers', 'inference_execution_policies', 'primary_release_metric', 'secondary_evaluation_metrics']:
+                    'detection_post_urls', 'detection_thresholds', 'subject_weights', 'custom_fields',
+                    'app_type_config', 'edgeflow_upload_policies', 'override_upstream_detection_filter',
+                    'feedback_resample_ratio', 'reviewers', 'inference_execution_policies',
+                    'primary_release_metric', 'secondary_evaluation_metrics']:
             data = {name: value}
             self.__post_update__(data)
             return

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='cogniac',
-      version='2.0.18',
+      version='2.0.19',
       description='Python SDK for Cogniac Public API',
       packages=['cogniac'],
       author = 'Cogniac Corporation',


### PR DESCRIPTION
Allow setting subject_weights (dict keyed by subject_uid with float values) on CogniacApplication objects, enabling auto-sync to the API on assignment like other mutable fields.