### PR TITLE
Fix url_prefix being overwritten by tenant region

### DIFF
--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -161,8 +161,8 @@ class CogniacConnection(object):
         # get tenant and user objects associated with this connection
         if self.tenant_id is not None:
             self._tenant = CogniacTenant.get(self)
-            if self._tenant.region is not None:
-                # use tenant object's specified region preference
+            if self._tenant.region is not None and url_prefix is None and 'COG_URL_PREFIX' not in os.environ:
+                # use tenant object's specified region preference unless explicitly overridden
                 self.url_prefix = 'https://' + self._tenant.region
         else:
             self._tenant = None

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='cogniac',
-      version='2.0.19',
+      version='2.0.20',
       description='Python SDK for Cogniac Public API',
       packages=['cogniac'],
       author = 'Cogniac Corporation',


### PR DESCRIPTION
## Summary
- Honor explicitly-provided `url_prefix` parameter and `COG_URL_PREFIX` env var instead of silently overwriting them with the tenant's region
- Bump version to 2.0.20

Fixes #92

## Test plan
- [ ] Verify `CogniacConnection(url_prefix="https://staging.cogniac.io")` retains the staging URL after connection
- [ ] Verify default behavior (no explicit url_prefix) still applies tenant region as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)