### PR TITLE
Add SDK + CLI support for leaderboard and evaluation_metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,8 @@ cogniac tenant                  # current tenant info
 cogniac tenants                 # list all authorized tenants (no COG_TENANT needed)
 cogniac apps list               # list all applications
 cogniac apps get <id>           # get specific application
+cogniac apps leaderboard <id>   # ranked candidate-model snapshot: --set-assignment, --snapshot-type, --eval-metrics, --top, --full
+cogniac apps eval-metrics <id>  # active evaluation metrics for an app (table shows weighted vs unweighted)
 cogniac subjects list           # list all subjects
 cogniac subjects get <uid>      # get specific subject
 cogniac subjects search         # search: --prefix, --similar, --name, --ids, --limit

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Agent-friendly CLI with JSON output (default) or `--format table`.
 cogniac auth                            # check credentials
 cogniac tenant                          # current tenant info
 cogniac apps list                       # list applications
+cogniac apps leaderboard <id>           # ranked candidate-model snapshot
+cogniac apps eval-metrics <id>          # active evaluation metrics
 cogniac subjects list                   # list subjects
 cogniac subjects search --prefix test   # search subjects
 cogniac media get <media_id>            # get media metadata

--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -416,6 +416,61 @@ class CogniacApplication(object):
                     return
             url = resp['paging'].get('next')
 
+    ##
+    #  leaderboard
+    ##
+    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+    def leaderboard(self,
+                    set_assignment='validation',
+                    snapshot_type='regular',
+                    eval_metrics='primary'):
+        """
+        Return the most recent ranked snapshot of candidate models for this application,
+        evaluated under the application's active evaluation metrics.
+
+        set_assignment (str):  'validation' (default) or 'training'
+        snapshot_type (str):   'regular' (default) or 'int8'
+        eval_metrics (str):    'primary' (default) for the primary metric only, or 'all'
+                               for results across all active metrics
+
+        Returns the raw response dict including:
+            app_id, leaderboard_timestamp, snapshot (list of ranked candidate models),
+            evaluation_metrics, primary_evaluation_metric_hash,
+            consensus_release_id, consensus_release_timestamp.
+
+        If results are not yet available, returns a dict {'message': ...} from the
+        202 response (e.g., when no consensus snapshot exists yet for the metric).
+        """
+        for arg, val, choices in [
+                ('set_assignment', set_assignment, ('validation', 'training')),
+                ('snapshot_type', snapshot_type, ('regular', 'int8')),
+                ('eval_metrics', eval_metrics, ('primary', 'all'))]:
+            if val not in choices:
+                raise ValueError("%s must be one of %s" % (arg, choices))
+
+        url = "/22/applications/%s/leaderboard/recent_consensus_snapshot" % self.application_id
+        params = {
+            'set_assignment': set_assignment,
+            'snapshot_type': snapshot_type,
+            'eval_metrics': eval_metrics,
+        }
+        resp = self._cc._get(url, params=params)
+        return resp.json()
+
+    ##
+    #  evaluation_metrics
+    ##
+    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+    def evaluation_metrics(self):
+        """
+        Return the list of active evaluation metrics for this application.
+
+        Each entry includes the metric hash, name, parameters (e.g., subject weights),
+        active flag, primary flag, and user_tag.
+        """
+        resp = self._cc._get("/22/applications/%s/evaluation_metrics" % self.application_id)
+        return resp.json()
+
     def accumulate_usage(self, start, end):
         """
         return single cummulative app usage record for start to end epoch times

--- a/cogniac/async_app.py
+++ b/cogniac/async_app.py
@@ -342,6 +342,50 @@ class AsyncCogniacApplication(object):
             url = resp.get('paging', {}).get('next')
 
     ##
+    #  leaderboard
+    ##
+    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+    async def leaderboard(self,
+                          set_assignment='validation',
+                          snapshot_type='regular',
+                          eval_metrics='primary'):
+        """
+        Return the most recent ranked snapshot of candidate models for this application,
+        evaluated under the application's active evaluation metrics.
+
+        set_assignment (str):  'validation' (default) or 'training'
+        snapshot_type (str):   'regular' (default) or 'int8'
+        eval_metrics (str):    'primary' (default) for the primary metric only, or 'all'
+                               for results across all active metrics
+        """
+        for arg, val, choices in [
+                ('set_assignment', set_assignment, ('validation', 'training')),
+                ('snapshot_type', snapshot_type, ('regular', 'int8')),
+                ('eval_metrics', eval_metrics, ('primary', 'all'))]:
+            if val not in choices:
+                raise ValueError("%s must be one of %s" % (arg, choices))
+
+        url = "/22/applications/%s/leaderboard/recent_consensus_snapshot" % self.application_id
+        params = {
+            'set_assignment': set_assignment,
+            'snapshot_type': snapshot_type,
+            'eval_metrics': eval_metrics,
+        }
+        resp = await self._cc._get(url, params=params)
+        return resp.json()
+
+    ##
+    #  evaluation_metrics
+    ##
+    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+    async def evaluation_metrics(self):
+        """
+        Return the list of active evaluation metrics for this application.
+        """
+        resp = await self._cc._get("/22/applications/%s/evaluation_metrics" % self.application_id)
+        return resp.json()
+
+    ##
     #  usage
     ##
     async def usage(self, start, end):

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -8,6 +8,8 @@ Read commands:
     cogniac tenants
     cogniac apps list
     cogniac apps get <application_id>
+    cogniac apps leaderboard <application_id> [--set-assignment validation|training] [--snapshot-type regular|int8] [--eval-metrics primary|all]
+    cogniac apps eval-metrics list <application_id>
     cogniac subjects list
     cogniac subjects get <subject_uid>
     cogniac subjects search [--prefix P] [--name N] [--similar S] [--ids ID ...] [--limit L]
@@ -64,6 +66,8 @@ _TABLE_COLUMNS = {
     'media_assoc': ['media_id', 'subject_uid', 'probability', 'consensus', 'updated_at'],
     'deployment': ['deployment_group_id', 'name', 'target_workflow_id', 'current_workflow_id'],
     'workflow':   ['workflow_id', 'name', 'tenant_id', 'created_at', 'created_by'],
+    'leaderboard': ['rank', 'model_id', 'model_runtime_image', 'model_image_id'],
+    'eval_metric': ['evaluation_metric_hash', 'name', 'primary', 'active', 'user_tag'],
 }
 
 
@@ -167,6 +171,62 @@ def cmd_apps_get(args):
     try:
         app = cc.get_application(args.application_id)
         output(obj_to_dict(app), args, 'app')
+    except ClientError as e:
+        error_exit("ClientError", str(e))
+
+
+def cmd_apps_leaderboard(args):
+    cc = get_connection()
+    try:
+        app = cc.get_application(args.application_id)
+        result = app.leaderboard(
+            set_assignment=args.set_assignment,
+            snapshot_type=args.snapshot_type,
+            eval_metrics=args.eval_metrics,
+        )
+        fmt = getattr(args, 'format', 'json')
+        if fmt == 'table':
+            snapshot = result.get('snapshot') if isinstance(result, dict) else None
+            if not snapshot:
+                # 202 / not-yet-available case — fall back to JSON so the message is visible
+                print(json.dumps(result, indent=2, default=str))
+                return
+            rows = []
+            for entry in snapshot:
+                rows.append({
+                    'rank': entry.get('primary_metric_rank', ''),
+                    'model_id': entry.get('model_id', ''),
+                    'model_runtime_image': entry.get('model_runtime_image', ''),
+                    'model_image_id': entry.get('model_image_id', ''),
+                })
+            output(rows, args, 'leaderboard')
+        else:
+            output(result, args)
+    except ClientError as e:
+        error_exit("ClientError", str(e))
+
+
+def cmd_apps_eval_metrics_list(args):
+    cc = get_connection()
+    try:
+        app = cc.get_application(args.application_id)
+        metrics = app.evaluation_metrics()
+        items = metrics.get('data', metrics) if isinstance(metrics, dict) else metrics
+        fmt = getattr(args, 'format', 'json')
+        if fmt == 'table' and isinstance(items, list):
+            rows = []
+            for m in items:
+                em = m.get('evaluation_metric', {}) if isinstance(m, dict) else {}
+                rows.append({
+                    'evaluation_metric_hash': m.get('evaluation_metric_hash', ''),
+                    'name': em.get('name', ''),
+                    'primary': m.get('primary', ''),
+                    'active': m.get('active', ''),
+                    'user_tag': m.get('user_tag', ''),
+                })
+            output(rows, args, 'eval_metric')
+        else:
+            output(items, args)
     except ClientError as e:
         error_exit("ClientError", str(e))
 
@@ -472,6 +532,27 @@ def build_parser():
     p = apps_sub.add_parser('get', help='Get a specific application')
     p.add_argument('application_id', help='Application ID')
     p.set_defaults(func=cmd_apps_get)
+
+    p = apps_sub.add_parser('leaderboard',
+                            help='Show the most recent ranked candidate-model snapshot for an application')
+    p.add_argument('application_id', help='Application ID')
+    p.add_argument('--set-assignment', dest='set_assignment',
+                   choices=['validation', 'training'], default='validation',
+                   help='Set assignment to evaluate against (default: validation)')
+    p.add_argument('--snapshot-type', dest='snapshot_type',
+                   choices=['regular', 'int8'], default='regular',
+                   help='Snapshot type (default: regular)')
+    p.add_argument('--eval-metrics', dest='eval_metrics',
+                   choices=['primary', 'all'], default='primary',
+                   help='Return primary metric only or all active metrics (default: primary)')
+    p.set_defaults(func=cmd_apps_leaderboard)
+
+    p = apps_sub.add_parser('eval-metrics',
+                            help='Evaluation metrics configured for an application')
+    em_sub = p.add_subparsers(dest='eval_metrics_command')
+    p2 = em_sub.add_parser('list', help='List active evaluation metrics for an application')
+    p2.add_argument('application_id', help='Application ID')
+    p2.set_defaults(func=cmd_apps_eval_metrics_list)
 
     # cogniac subjects
     subjects_parser = subparsers.add_parser('subjects', help='Subjects')

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -8,8 +8,8 @@ Read commands:
     cogniac tenants
     cogniac apps list
     cogniac apps get <application_id>
-    cogniac apps leaderboard <application_id> [--set-assignment validation|training] [--snapshot-type regular|int8] [--eval-metrics primary|all]
-    cogniac apps eval-metrics list <application_id>
+    cogniac apps leaderboard <application_id> [--set-assignment validation|training] [--snapshot-type regular|int8] [--eval-metrics primary|all] [--top N] [--full]
+    cogniac apps eval-metrics <application_id>
     cogniac subjects list
     cogniac subjects get <subject_uid>
     cogniac subjects search [--prefix P] [--name N] [--similar S] [--ids ID ...] [--limit L]
@@ -66,8 +66,8 @@ _TABLE_COLUMNS = {
     'media_assoc': ['media_id', 'subject_uid', 'probability', 'consensus', 'updated_at'],
     'deployment': ['deployment_group_id', 'name', 'target_workflow_id', 'current_workflow_id'],
     'workflow':   ['workflow_id', 'name', 'tenant_id', 'created_at', 'created_by'],
-    'leaderboard': ['rank', 'model_id', 'model_runtime_image', 'model_image_id'],
-    'eval_metric': ['evaluation_metric_hash', 'name', 'primary', 'active', 'user_tag'],
+    'leaderboard': ['rank', 'model_id', 'F1', 'precision', 'recall', 'TP', 'FP', 'FN', 'model_image_id'],
+    'eval_metric': ['evaluation_metric_hash', 'name', 'primary', 'active', 'weighted', 'user_tag'],
 }
 
 
@@ -175,6 +175,30 @@ def cmd_apps_get(args):
         error_exit("ClientError", str(e))
 
 
+def _round_metric(v):
+    """Round metric floats to 4 decimals for display; pass through non-floats."""
+    return round(v, 4) if isinstance(v, float) else v
+
+
+def _strip_subj_results(snapshot):
+    """Return a deep-ish copy of snapshot entries with per-subject breakdowns dropped."""
+    brief = []
+    for entry in snapshot:
+        e = dict(entry)
+        results = e.get('results')
+        if isinstance(results, dict):
+            new_results = {}
+            for h, v in results.items():
+                if isinstance(v, dict) and isinstance(v.get('result'), dict):
+                    inner = {k: val for k, val in v['result'].items() if k != 'subj_results'}
+                    new_results[h] = {**v, 'result': inner}
+                else:
+                    new_results[h] = v
+            e['results'] = new_results
+        brief.append(e)
+    return brief
+
+
 def cmd_apps_leaderboard(args):
     cc = get_connection()
     try:
@@ -185,22 +209,48 @@ def cmd_apps_leaderboard(args):
             eval_metrics=args.eval_metrics,
         )
         fmt = getattr(args, 'format', 'json')
+        snapshot = result.get('snapshot') if isinstance(result, dict) else None
+        primary_hash = result.get('primary_evaluation_metric_hash') if isinstance(result, dict) else None
+        top = getattr(args, 'top', None)
+
         if fmt == 'table':
-            snapshot = result.get('snapshot') if isinstance(result, dict) else None
             if not snapshot:
-                # 202 / not-yet-available case — fall back to JSON so the message is visible
+                # 202 / not-yet-available — fall back to JSON so the message is visible
                 print(json.dumps(result, indent=2, default=str))
                 return
             rows = []
             for entry in snapshot:
+                app_res = (entry.get('results', {})
+                                .get(primary_hash, {})
+                                .get('result', {})
+                                .get('app_results', {})) if primary_hash else {}
                 rows.append({
                     'rank': entry.get('primary_metric_rank', ''),
                     'model_id': entry.get('model_id', ''),
-                    'model_runtime_image': entry.get('model_runtime_image', ''),
+                    'F1': _round_metric(app_res.get('F1', '')),
+                    'precision': _round_metric(app_res.get('precision', '')),
+                    'recall': _round_metric(app_res.get('recall', '')),
+                    'TP': app_res.get('TP', ''),
+                    'FP': app_res.get('FP', ''),
+                    'FN': app_res.get('FN', ''),
                     'model_image_id': entry.get('model_image_id', ''),
                 })
+            if top:
+                rows = rows[:top]
             output(rows, args, 'leaderboard')
+            return
+
+        # JSON output: brief by default, --full for raw
+        if not args.full and snapshot:
+            brief = dict(result)
+            brief['snapshot'] = _strip_subj_results(snapshot)
+            if top:
+                brief['snapshot'] = brief['snapshot'][:top]
+            output(brief, args)
         else:
+            if top and snapshot:
+                result = dict(result)
+                result['snapshot'] = snapshot[:top]
             output(result, args)
     except ClientError as e:
         error_exit("ClientError", str(e))
@@ -217,11 +267,14 @@ def cmd_apps_eval_metrics_list(args):
             rows = []
             for m in items:
                 em = m.get('evaluation_metric', {}) if isinstance(m, dict) else {}
+                weights = em.get('subject_weights') or {}
+                weighted = bool(weights) and len(set(weights.values())) > 1
                 rows.append({
                     'evaluation_metric_hash': m.get('evaluation_metric_hash', ''),
                     'name': em.get('name', ''),
                     'primary': m.get('primary', ''),
                     'active': m.get('active', ''),
+                    'weighted': weighted,
                     'user_tag': m.get('user_tag', ''),
                 })
             output(rows, args, 'eval_metric')
@@ -545,14 +598,16 @@ def build_parser():
     p.add_argument('--eval-metrics', dest='eval_metrics',
                    choices=['primary', 'all'], default='primary',
                    help='Return primary metric only or all active metrics (default: primary)')
+    p.add_argument('--top', type=int, default=None,
+                   help='Show only the top N ranked models (default: all returned)')
+    p.add_argument('--full', action='store_true',
+                   help='Include per-subject metric breakdowns in JSON output (omitted by default)')
     p.set_defaults(func=cmd_apps_leaderboard)
 
     p = apps_sub.add_parser('eval-metrics',
-                            help='Evaluation metrics configured for an application')
-    em_sub = p.add_subparsers(dest='eval_metrics_command')
-    p2 = em_sub.add_parser('list', help='List active evaluation metrics for an application')
-    p2.add_argument('application_id', help='Application ID')
-    p2.set_defaults(func=cmd_apps_eval_metrics_list)
+                            help='List active evaluation metrics for an application')
+    p.add_argument('application_id', help='Application ID')
+    p.set_defaults(func=cmd_apps_eval_metrics_list)
 
     # cogniac subjects
     subjects_parser = subparsers.add_parser('subjects', help='Subjects')

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -47,3 +47,40 @@ class TestAppRead:
                 assert 'media' in dets[0] or 'media_id' in dets[0]
                 return
         pytest.skip("No apps with detections found")
+
+    def test_app_evaluation_metrics(self, cc):
+        """Find an app with eval metrics configured and validate response shape."""
+        apps = cc.get_all_applications()
+        for app in apps:
+            metrics = app.evaluation_metrics()
+            items = metrics.get('data', metrics) if isinstance(metrics, dict) else metrics
+            if isinstance(items, list) and len(items) > 0:
+                m = items[0]
+                assert 'evaluation_metric_hash' in m
+                assert 'evaluation_metric' in m
+                assert 'name' in m['evaluation_metric']
+                return
+        pytest.skip("No apps with evaluation metrics configured")
+
+    def test_app_leaderboard(self, cc):
+        """Find an app with a ready leaderboard snapshot and validate response shape."""
+        apps = cc.get_all_applications()
+        for app in apps:
+            result = app.leaderboard()
+            if isinstance(result, dict) and 'snapshot' in result:
+                assert result.get('app_id') == app.application_id
+                assert 'primary_evaluation_metric_hash' in result
+                assert isinstance(result['snapshot'], list)
+                return
+        pytest.skip("No app with a ready leaderboard snapshot found")
+
+    def test_app_leaderboard_validates_args(self, cc):
+        """Bad enum values should raise ValueError before any HTTP call."""
+        apps = cc.get_all_applications()
+        app = apps[0]
+        with pytest.raises(ValueError):
+            app.leaderboard(set_assignment='bogus')
+        with pytest.raises(ValueError):
+            app.leaderboard(snapshot_type='bogus')
+        with pytest.raises(ValueError):
+            app.leaderboard(eval_metrics='bogus')

--- a/tests/test_async_apps.py
+++ b/tests/test_async_apps.py
@@ -64,3 +64,43 @@ class TestAsyncAppRead:
                 if len(dets) > 0:
                     return
             pytest.skip("No apps with detections found")
+
+    @pytest.mark.asyncio
+    async def test_evaluation_metrics(self):
+        async with await cogniac.AsyncCogniacConnection.create() as cc:
+            apps = await cogniac.AsyncCogniacApplication.get_all(cc)
+            for app in apps:
+                metrics = await app.evaluation_metrics()
+                items = metrics.get('data', metrics) if isinstance(metrics, dict) else metrics
+                if isinstance(items, list) and len(items) > 0:
+                    m = items[0]
+                    assert 'evaluation_metric_hash' in m
+                    assert 'evaluation_metric' in m
+                    assert 'name' in m['evaluation_metric']
+                    return
+            pytest.skip("No apps with evaluation metrics configured")
+
+    @pytest.mark.asyncio
+    async def test_leaderboard(self):
+        async with await cogniac.AsyncCogniacConnection.create() as cc:
+            apps = await cogniac.AsyncCogniacApplication.get_all(cc)
+            for app in apps:
+                result = await app.leaderboard()
+                if isinstance(result, dict) and 'snapshot' in result:
+                    assert result.get('app_id') == app.application_id
+                    assert 'primary_evaluation_metric_hash' in result
+                    assert isinstance(result['snapshot'], list)
+                    return
+            pytest.skip("No app with a ready leaderboard snapshot found")
+
+    @pytest.mark.asyncio
+    async def test_leaderboard_validates_args(self):
+        async with await cogniac.AsyncCogniacConnection.create() as cc:
+            apps = await cogniac.AsyncCogniacApplication.get_all(cc)
+            app = apps[0]
+            with pytest.raises(ValueError):
+                await app.leaderboard(set_assignment='bogus')
+            with pytest.raises(ValueError):
+                await app.leaderboard(snapshot_type='bogus')
+            with pytest.raises(ValueError):
+                await app.leaderboard(eval_metrics='bogus')


### PR DESCRIPTION
## Summary
- Adds `app.leaderboard()` and `app.evaluation_metrics()` methods to both sync and async `CogniacApplication`, wrapping `/22/applications/{app_id}/leaderboard/recent_consensus_snapshot` and `/22/applications/{app_id}/evaluation_metrics`
- Adds `cogniac apps leaderboard` and `cogniac apps eval-metrics list` CLI subcommands with JSON (default) and table output
- Closes #145

Previously these endpoints were only reachable via raw `cc.session.get(...)`, which most users wouldn't realize was an option.

## Test plan
- [x] `cogniac apps leaderboard <app_id>` returns a snapshot dict; table output renders rank/model_id/runtime/image_id
- [x] `cogniac apps leaderboard <app_id> --eval-metrics all` returns all active metrics
- [x] `cogniac apps leaderboard <app_id> --snapshot-type int8` returns 202 not-available message cleanly
- [x] `cogniac apps eval-metrics list <app_id>` table shows hash/name/primary/active/user_tag
- [x] 404 (unknown app) returns clean JSON error
- [x] argparse rejects bad `--snapshot-type` values
- [x] SDK raises `ValueError` for invalid arg values
- [x] Tested against `lhb02qed` (sandbox) and `evgmuozp` (production) in tenant `ku2a6orm8w7p`

## Out of scope (per #145)
Write-side eval-metric ops (register, register-default, copy) — these change which model the app would promote, deferred until the workflow is documented.

## Follow-up
Ergonomic enhancements being explored in subsequent commits to this branch (richer table output, brief vs full JSON, weighted-vs-unweighted surfacing on eval-metrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)