### PR TITLE
subject: allow consensus=True/False with associate_media()

### DIFF
--- a/cogniac/async_subject.py
+++ b/cogniac/async_subject.py
@@ -256,8 +256,7 @@ class AsyncCogniacSubject(object):
         if consensus == 'None' and probability is None:
             data['uncal_prob'] = .99
 
-        if probability is not None:
-            assert(consensus == 'None')
+        if probability is not None and consensus == 'None':
             data['uncal_prob'] = probability
 
         if enable_wait_result:

--- a/cogniac/subject.py
+++ b/cogniac/subject.py
@@ -401,8 +401,7 @@ class CogniacSubject(object):
         if consensus == 'None' and probability is None:
             data['uncal_prob'] = .99
 
-        if probability is not None:
-            assert(consensus == 'None')
+        if probability is not None and consensus == 'None':
             data['uncal_prob'] = probability
 
         if enable_wait_result:


### PR DESCRIPTION
## What

Removes an overly strict assertion in `CogniacSubject.associate_media()` (and its async counterpart) that raised `AssertionError` when callers passed `probability` alongside an explicit `consensus` value.

## Why

`consensus='True'` or `'False'` associations don't use `probability` — it's irrelevant when consensus is explicitly set. The old behavior forced callers working with consensus GT data (e.g. segmentation apps that need `consensus=True, focus=box`) to drop down to raw HTTP calls:

```python
# Workaround that should no longer be necessary:
cc.session.post(".../1/subjects/%s/media" % uid, json={
    "media_id": mid, "consensus": "True", "focus": {"box": box}, ...
})
```

With this fix, `associate_media(media, focus=focus, consensus='True', ...)` works correctly whether or not `probability` is also passed — `probability` is simply ignored when consensus is not `'None'`.

The fix is identical in `subject.py` and `async_subject.py`.

## Test

```python
subject.associate_media(media, focus={"box": {...}}, consensus='True')  # no longer raises
subject.associate_media(media, focus={"box": {...}}, consensus='False') # no longer raises
subject.associate_media(media, probability=0.9)                         # unchanged
```

Fixes Cogniac/cogniac-kb#38
Refs Cogniac/CloudCore-Product#996

cc @wskish