### PR TITLE
Add cogniac --version flag; bump to 3.0.3

### DIFF
--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -43,10 +43,16 @@ import argparse
 import json
 import sys
 import os
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
 
 from tabulate import tabulate
 
 from .cogniac import CogniacConnection
+
+try:
+    __pkg_version__ = _pkg_version("cogniac")
+except PackageNotFoundError:
+    __pkg_version__ = "unknown"
 from .common import CredentialError, ServerError, ClientError, raise_errors
 
 # Attributes set by SDK internals, not from the API response
@@ -572,6 +578,9 @@ def build_parser():
                         help='Output format (default: json)')
     parser.add_argument('--tenant', default=None,
                         help='Tenant ID to use for this invocation (overrides COG_TENANT)')
+    parser.add_argument('--version', action='version',
+                        version=f'cogniac {__pkg_version__}',
+                        help='Show installed cogniac package version and exit')
     subparsers = parser.add_subparsers(dest='command')
 
     # cogniac tenant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cogniac"
-version = "3.0.2"
+version = "3.0.3"
 description = "Python SDK for Cogniac Public API"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Add top-level `--version` flag that prints the installed `cogniac` package version (via `importlib.metadata`) and exits.
- Bump package to 3.0.3.

Distinct from the existing `cogniac version` subcommand, which hits the API and reports the *remote* API version (and requires auth + tenant). `--version` is local and free.

## Test plan
- [x] `cogniac --version` prints `cogniac 3.0.3` after `uv tool install --reinstall -e .`
- [x] `cogniac --help` lists `[--version]`
- [x] `cogniac version` (subcommand) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)