### PR TITLE
cli: accept --tenant_id as an alias for --tenant

### DIFF
--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -576,8 +576,9 @@ def build_parser():
     )
     parser.add_argument('--format', choices=['json', 'table'], default='json',
                         help='Output format (default: json)')
-    parser.add_argument('--tenant', default=None,
-                        help='Tenant ID to use for this invocation (overrides COG_TENANT)')
+    parser.add_argument('--tenant', '--tenant_id', default=None,
+                        help='Tenant ID to use for this invocation (overrides COG_TENANT). '
+                             '`--tenant_id` is an alias for ergonomics.')
     parser.add_argument('--version', action='version',
                         version=f'cogniac {__pkg_version__}',
                         help='Show installed cogniac package version and exit')


### PR DESCRIPTION
## Summary

One-line argparse change adding `--tenant_id` as an alias for the existing `--tenant` flag from #149. No behavior change; both forms set the same `tenant` attribute.

## Who / What / When / Where / Why

- **Who** — @bjw-0 (Claude B). cc: @wskish (author of #149).
- **What** — `parser.add_argument('--tenant', '--tenant_id', default=None, ...)` in `cogniac/cli.py:579`. Argparse handles the rest natively.
- **When** — Now. Trivial; useful as soon as it lands.
- **Where** — `cogniac/cli.py` only.
- **Why** — Following a request from @wskish (author of #149) for the CLI to accept `--tenant_id` in addition to `COG_TENANT` (agents kept reaching for the more-explicit form). The flag that shipped in #149 is actually `--tenant` — `--tenant_id` was rejected by argparse on 3.0.3. This PR closes that gap: agents (and humans typing the more-explicit form) get a working CLI regardless of which alias they reach for.

## Verification

```
$ cogniac --tenant_id abc123def456 tenant    # pre-diff
cogniac: error: argument command: invalid choice: 'abc123def456'

$ cogniac --tenant_id abc123def456 tenant    # post-diff
{"error": "ConnectionError", "detail": "No Cogniac Credentials..."}   # argparse accepted; failed at auth as expected

$ cogniac --tenant abc123def456 tenant       # post-diff (unchanged)
{"error": "ConnectionError", ...}
```

## Test plan

- [x] argparse accepts both `--tenant` and `--tenant_id`
- [x] both forms reach the same `args.tenant` attribute (argparse dest defaults to first long option)
- [ ] add a unit test in `tests/test_cli.py` if reviewer wants — happy to extend; left out of this minimal diff for review surface
- [ ] no version bump needed (alias is purely additive); could bump to 3.0.4 if you prefer to signal it explicitly in release notes

— Claude B (for @bjw-0)
