### PR TITLE
Fix cogniac auth confidence trap; bump to 3.0.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Agent-friendly CLI. JSON output by default, `--format table` for human-readable.
 
 Read commands:
 ```
-cogniac auth                    # check credentials and connectivity
+cogniac auth                    # check credentials; with --tenant/COG_TENANT, also verifies a session can be minted
 cogniac tenant                  # current tenant info
 cogniac tenants                 # list all authorized tenants (no COG_TENANT needed)
 cogniac apps list               # list all applications

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Every sync entity class has an async counterpart prefixed with `Async` (e.g., `A
 Agent-friendly CLI with JSON output (default) or `--format table`.
 
 ```bash
-cogniac auth                            # check credentials
+cogniac auth                            # check credentials (add --tenant <id> to verify a session)
 cogniac tenant                          # current tenant info
 cogniac apps list                       # list applications
 cogniac apps leaderboard <id>           # ranked candidate-model snapshot

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -481,7 +481,8 @@ def cmd_version(args):
 
 
 def cmd_auth(args):
-    """Check that credentials are valid without making a full connection."""
+    """Check credentials. If a tenant is specified (via --tenant or COG_TENANT),
+    also verify that a real session can be minted against it via /1/token."""
     has_api_key = 'COG_API_KEY' in os.environ
     has_user_pass = 'COG_USER' in os.environ and 'COG_PASS' in os.environ
     flag_tenant = getattr(args, 'tenant', None)
@@ -501,14 +502,29 @@ def cmd_auth(args):
         result["tenant_source"] = "flag" if flag_tenant else "env"
 
     url_prefix = os.environ.get('COG_URL_PREFIX', 'https://api.cogniac.io/')
+    result["url_prefix"] = url_prefix
     try:
         tenants = CogniacConnection.get_all_authorized_tenants(url_prefix=url_prefix)
-        result["valid"] = True
         result["tenant_count"] = len(tenants.get('tenants', []))
-        result["url_prefix"] = url_prefix
     except Exception as e:
         result["valid"] = False
         result["detail"] = str(e)
+        output(result, args)
+        return
+
+    if effective_tenant:
+        try:
+            CogniacConnection(tenant_id=effective_tenant, url_prefix=url_prefix)
+            result["valid"] = True
+        except Exception as e:
+            result["valid"] = False
+            result["detail"] = str(e)
+    else:
+        result["valid"] = True
+        result["note"] = (
+            "Credentials valid. List tenants with `cogniac tenants`, then pass "
+            "--tenant <id> (or set COG_TENANT) to work with the specified tenant."
+        )
 
     output(result, args)
 
@@ -749,7 +765,7 @@ def build_parser():
     p.set_defaults(func=cmd_workflows_get)
 
     # cogniac auth
-    p = subparsers.add_parser('auth', help='Check credentials and connectivity')
+    p = subparsers.add_parser('auth', help='Check credentials; if --tenant/COG_TENANT is set, verify a session can be minted')
     p.set_defaults(func=cmd_auth)
 
     # cogniac user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cogniac"
-version = "3.0.3"
+version = "3.0.4"
 description = "Python SDK for Cogniac Public API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "cogniac"
-version = "3.0.0"
+version = "3.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- `cogniac auth` previously reported `valid: true` whenever `get_all_authorized_tenants()` succeeded — including for nonexistent or unauthorized tenants passed via `--tenant`/`COG_TENANT`, because the `/1/token` exchange was never exercised.
- When a tenant is specified, now build a `CogniacConnection(tenant_id=...)` so the token exchange runs and `valid` reflects whether a real session can be minted. Failures surface the actual API error.
- When no tenant is specified, keep `valid: true` (credentials really are recognized) but add a `note` directing the caller to pick a tenant via `cogniac tenants` + `--tenant`. This addresses agent feedback that `cogniac auth` without a tenant was a confidence trap.

## Behavior
```
$ cogniac auth                                     # no tenant
{ "valid": true, "tenant_count": 443,
  "note": "Credentials valid. List tenants with `cogniac tenants`, then pass --tenant <id> ..." }

$ cogniac --tenant fake auth
{ "valid": false, "detail": "ClientError (400): {\"message\":\"Unauthorized\"}\n" }

$ cogniac --tenant w26eek85g3o1 auth
{ "valid": true, "tenant_id": "w26eek85g3o1", "tenant_source": "flag" }
```

## Test plan
- [x] `cogniac auth` with no tenant → `valid: true`, `note` present
- [x] `cogniac --tenant <fake> auth` → `valid: false` with `/1/token` error
- [x] `cogniac --tenant <real> auth` → `valid: true`
- [x] `COG_TENANT=<real> cogniac auth` → `valid: true`, `tenant_source: "env"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)