### PR TITLE
Fix post_feedback dropping per-ROI focus; bump to 3.0.5

### DIFF
--- a/cogniac/app.py
+++ b/cogniac/app.py
@@ -225,7 +225,7 @@ class CogniacApplication(object):
     #  post_feedback
     ##
     @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
-    def post_feedback(self, media_id, subjects):
+    def post_feedback(self, media_id, subjects, focus=None):
         """
         Provides feedback to the application for a given subject-media assocation; returns None.
 
@@ -237,6 +237,12 @@ class CogniacApplication(object):
             app_data_type (String):    (Optional) Type of extra app-specific data for certain app types
             app_data (Object):         (Optional) Additional, app-specific, subject-media association data
 
+        focus (dict, optional):        Focus within the media this feedback applies to. Required when
+                                       the output subject's labels carry per-ROI focus (e.g. box_detection
+                                       apps or focus-aware classifiers). Shape:
+                                       {'box': {'x0': int, 'x1': int, 'y0': int, 'y1': int}}
+                                       (and/or 'frame' for video). Note: a 'focus' key placed inside a
+                                       subject dict is NOT read by the server — it must be passed here.
         """
         # add media_id to each subject-media association dict
         # TODO: deprecate this
@@ -245,6 +251,8 @@ class CogniacApplication(object):
 
         feedback_response = {'media_id': media_id,
                              'subjects': subjects}
+        if focus is not None:
+            feedback_response['focus'] = focus
 
         self._cc._post("/21/applications/%s/feedback" % self.application_id, json=feedback_response)
 

--- a/cogniac/async_app.py
+++ b/cogniac/async_app.py
@@ -214,7 +214,7 @@ class AsyncCogniacApplication(object):
     #  post_feedback
     ##
     @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
-    async def post_feedback(self, media_id, subjects):
+    async def post_feedback(self, media_id, subjects, focus=None):
         """
         Provide feedback to the application for a given subject-media association.
 
@@ -224,12 +224,21 @@ class AsyncCogniacApplication(object):
             result (str):         One of 'True', 'False', 'Sidelined'
             app_data_type (str):  (Optional) type of extra app-specific data
             app_data (Object):    (Optional) additional app-specific data
+
+        focus (dict, optional):   Focus within the media this feedback applies to. Required when
+                                  the output subject's labels carry per-ROI focus (e.g. box_detection
+                                  apps or focus-aware classifiers). Shape:
+                                  {'box': {'x0': int, 'x1': int, 'y0': int, 'y1': int}}
+                                  (and/or 'frame' for video). Note: a 'focus' key placed inside a
+                                  subject dict is NOT read by the server — it must be passed here.
         """
         for s in subjects:
             s['media_id'] = media_id
 
         feedback_response = {'media_id': media_id,
                              'subjects': subjects}
+        if focus is not None:
+            feedback_response['focus'] = focus
 
         await self._cc._post("/21/applications/%s/feedback" % self.application_id, json=feedback_response)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cogniac"
-version = "3.0.4"
+version = "3.0.5"
 description = "Python SDK for Cogniac Public API"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Add `focus=None` kwarg to `CogniacApplication.post_feedback` (and the async counterpart) and forward it at the top level of the `/21/applications/<id>/feedback` payload.
- Document that a `focus` key placed inside a subject dict is ignored server-side — the trap that made the previous failure silent.
- Bump to 3.0.5.

Fixes #153.

## Test plan

- [ ] Against a box_detection app: `app.post_feedback(mid, [...], focus={'box': {...}})` results in an output-subject association with `focus={'box': {...}}` (not `None`).
- [ ] Calling without `focus` continues to work for apps that don't need it.
- [ ] Async path (`AsyncCogniacApplication.post_feedback`) behaves the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)