### PR TITLE
Add `cogniac auth login`: browser-loopback CLI login (CloudCore-Product#1026)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,17 @@ The SDK provides both synchronous and asynchronous interfaces. The sync API uses
 
 Environment variables: `COG_USER`, `COG_PASS`, `COG_API_KEY`, `COG_TENANT`, `COG_URL_PREFIX` (default `https://api.cogniac.io/`).
 
+### Credential sources and precedence
+
+Both connection classes resolve a credential in this order (first match wins):
+1. explicit `api_key` constructor argument
+2. explicit `username`+`password` constructor arguments
+3. `COG_API_KEY` env var
+4. `COG_USER`+`COG_PASS` env vars
+5. stored login at `~/.config/cogniac/credentials` (written by `cogniac auth login`)
+
+The stored credential is a tenant-less, per-user API key consumed exactly like `COG_API_KEY` (the SDK trades it for per-tenant tokens and re-mints on 401). When it is the active source, its recorded `url_prefix` is also adopted (unless `url_prefix`/`COG_URL_PREFIX` is set explicitly). `credentials.py` is the store (XDG-aware, 0600); `auth_login.py` implements the RFC 8252 browser-loopback flow (`cogniac auth login`/`auth logout` in the CLI). See CloudCore-Product#1026 — this is the Phase 1 CLI/SDK side (`state` CSRF guard, key-in-query, no backend changes; Phase 2 adds PKCE + a one-time-code exchange).
+
 ### Entity Classes
 
 Each API resource has a sync class and an async counterpart:
@@ -107,11 +118,17 @@ The CLI uses the sync API only.
 
 ## `cogniac` CLI Tool
 
-Agent-friendly CLI. JSON output by default, `--format table` for human-readable. Auth via env vars (`COG_USER`/`COG_PASS` or `COG_API_KEY`, plus `COG_TENANT`). The tenant can also be specified per-invocation with the top-level `--tenant <tenant_id>` flag, which overrides `COG_TENANT`.
+Agent-friendly CLI. JSON output by default, `--format table` for human-readable. Auth via env vars (`COG_USER`/`COG_PASS` or `COG_API_KEY`, plus `COG_TENANT`) **or** a stored login from `cogniac auth login`. The tenant can also be specified per-invocation with the top-level `--tenant <tenant_id>` flag, which overrides `COG_TENANT`.
+
+Auth commands:
+```
+cogniac auth                    # check credentials; with --tenant/COG_TENANT, also verifies a session can be minted
+cogniac auth login              # browser-loopback login; stores a per-user API key at ~/.config/cogniac/credentials (0600). --no-browser prints the URL instead of opening it
+cogniac auth logout             # remove the stored login credential
+```
 
 Read commands:
 ```
-cogniac auth                    # check credentials; with --tenant/COG_TENANT, also verifies a session can be minted
 cogniac tenant                  # current tenant info
 cogniac tenants                 # list all authorized tenants (no COG_TENANT needed)
 cogniac apps list               # list all applications

--- a/cogniac/async_connection.py
+++ b/cogniac/async_connection.py
@@ -12,6 +12,7 @@ import re
 import httpx
 from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception
 from .common import server_error, raise_errors, CredentialError, credential_error
+from .credentials import stored_api_key, stored_url_prefix
 
 DEFAULT_COG_URL_PREFIX = "https://api.cogniac.io/"
 
@@ -83,21 +84,27 @@ class AsyncCogniacConnection(object):
             self.password = password
         elif 'COG_API_KEY' in os.environ:
             self.api_key = os.environ['COG_API_KEY']
+        elif 'COG_USER' in os.environ and 'COG_PASS' in os.environ:
+            self.username = os.environ['COG_USER']
+            self.password = os.environ['COG_PASS']
+        elif stored_api_key() is not None:
+            # fall back to a credential stored by `cogniac auth login`
+            self.api_key = stored_api_key()
         else:
-            try:
-                self.username = os.environ['COG_USER']
-                self.password = os.environ['COG_PASS']
-            except KeyError:
-                raise Exception(
-                    "No Cogniac Credentials. Specify username and password "
-                    "or set COG_USER, COG_PASS or COG_API_KEY environment variables."
-                )
+            raise Exception(
+                "No Cogniac Credentials. Specify username and password, "
+                "set COG_USER, COG_PASS or COG_API_KEY environment variables, "
+                "or run `cogniac auth login`."
+            )
 
         # --- url prefix ---
         if url_prefix is not None:
             self.url_prefix = url_prefix
         elif 'COG_URL_PREFIX' in os.environ:
             self.url_prefix = os.environ['COG_URL_PREFIX']
+        elif stored_url_prefix() is not None:
+            # adopt the url_prefix recorded by `cogniac auth login`
+            self.url_prefix = stored_url_prefix()
         else:
             self.url_prefix = DEFAULT_COG_URL_PREFIX
 

--- a/cogniac/auth_login.py
+++ b/cogniac/auth_login.py
@@ -100,7 +100,7 @@ def login(url_prefix=None, open_browser=True, timeout=300, out=sys.stderr):
             code = params.get('code')
             if err:
                 result['error'] = "consent page reported: %s" % err
-            elif recv_state != state:
+            elif not secrets.compare_digest(recv_state or "", state):
                 result['error'] = "state mismatch (possible CSRF); login rejected"
             elif not code:
                 result['error'] = "no credential returned by consent page"
@@ -138,9 +138,6 @@ def login(url_prefix=None, open_browser=True, timeout=300, out=sys.stderr):
 
     try:
         finished = done.wait(timeout)
-    except KeyboardInterrupt:
-        server.shutdown()
-        raise
     finally:
         server.shutdown()
 

--- a/cogniac/auth_login.py
+++ b/cogniac/auth_login.py
@@ -1,0 +1,151 @@
+"""
+Browser-loopback CLI login for the Cogniac SDK (`cogniac auth login`).
+
+Implements the RFC 8252 "loopback redirect" pattern used by `gh auth login`,
+`gcloud auth login`, and `aws sso login`:
+
+    1. bind 127.0.0.1:<random ephemeral port>
+    2. generate a `state` CSRF token
+    3. open the browser at <web>/app/cli-auth?port=<port>&state=<state>
+    4. the web consent page authenticates the existing web session
+       (password OR SAML SSO), mints a tenant-less per-user API key via
+       POST /1/users/<uid>/apiKeys, then redirects the browser to
+       http://127.0.0.1:<port>/cb?code=<api_key>&state=<state>
+    5. this loopback listener catches the redirect, verifies `state`, and
+       hands the API key back to the caller.
+
+This is the Phase 1 (MVP) flow from CloudCore-Product#1026: key-in-query with a
+`state` CSRF guard, no backend changes. Phase 2 adds PKCE + a one-time-code
+exchange.
+
+Copyright (C) 2016 Cogniac Corporation.
+"""
+
+import http.server
+import secrets
+import sys
+import threading
+import urllib.parse
+import webbrowser
+
+DEFAULT_COG_URL_PREFIX = "https://api.cogniac.io/"
+
+# The consent page is served at the identical path in both the Ember and React
+# frontends; the cog_app cookie routes the browser to whichever one the user is
+# pinned to. The CLI is frontend-agnostic.
+CLI_AUTH_PATH = "/app/cli-auth"
+
+_SUCCESS_HTML = """<!doctype html><html><head><meta charset="utf-8">
+<title>Cogniac CLI login</title></head>
+<body style="font-family:system-ui,sans-serif;text-align:center;margin-top:4rem">
+<h2>You're logged in to the Cogniac CLI.</h2>
+<p>You can close this tab and return to your terminal.</p>
+</body></html>"""
+
+
+def _failure_html(reason):
+    return ("""<!doctype html><html><head><meta charset="utf-8">
+<title>Cogniac CLI login</title></head>
+<body style="font-family:system-ui,sans-serif;text-align:center;margin-top:4rem">
+<h2>Cogniac CLI login failed.</h2>
+<p>%s</p>
+<p>Return to your terminal and try again.</p>
+</body></html>""" % urllib.parse.quote(reason or "unknown error"))
+
+
+def web_base_url(api_url_prefix):
+    """Derive the web-app origin (scheme://host[:port]) from the API url_prefix.
+
+    Production splits the API onto an `api.` subdomain (api.cogniac.io) while the
+    web app is served from the bare host (cogniac.io). On-prem / staging serve
+    both from the same host, so only an explicit `api.` prefix is stripped.
+    """
+    p = urllib.parse.urlparse(api_url_prefix)
+    netloc = p.netloc or p.path  # tolerate a bare host with no scheme
+    scheme = p.scheme or "https"
+    if netloc.startswith("api."):
+        netloc = netloc[len("api."):]
+    return "%s://%s" % (scheme, netloc)
+
+
+def login(url_prefix=None, open_browser=True, timeout=300, out=sys.stderr):
+    """Run the browser-loopback login flow and return (api_key, url_prefix).
+
+    Raises Exception on timeout, state mismatch, or an error reported by the
+    consent page. `out` receives human-readable progress (default stderr so it
+    never pollutes CLI JSON on stdout).
+    """
+    if url_prefix is None:
+        import os
+        url_prefix = os.environ.get('COG_URL_PREFIX', DEFAULT_COG_URL_PREFIX)
+
+    web_base = web_base_url(url_prefix)
+    state = secrets.token_urlsafe(32)
+
+    done = threading.Event()
+    result = {}
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path != "/cb":
+                # ignore favicon.ico and any stray probes; keep listening
+                self.send_response(404)
+                self.end_headers()
+                return
+            params = {k: v[0] for k, v in urllib.parse.parse_qs(parsed.query).items()}
+            err = params.get('error')
+            recv_state = params.get('state')
+            code = params.get('code')
+            if err:
+                result['error'] = "consent page reported: %s" % err
+            elif recv_state != state:
+                result['error'] = "state mismatch (possible CSRF); login rejected"
+            elif not code:
+                result['error'] = "no credential returned by consent page"
+            else:
+                result['api_key'] = code
+
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html; charset=utf-8')
+            self.end_headers()
+            body = _SUCCESS_HTML if 'api_key' in result else _failure_html(result.get('error'))
+            self.wfile.write(body.encode('utf-8'))
+            done.set()
+
+        def log_message(self, *args):  # silence default request logging
+            pass
+
+    server = http.server.HTTPServer(('127.0.0.1', 0), _Handler)
+    port = server.server_address[1]
+    auth_url = "%s%s?%s" % (
+        web_base, CLI_AUTH_PATH,
+        urllib.parse.urlencode({"port": port, "state": state}),
+    )
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    opened = open_browser and webbrowser.open(auth_url)
+    if opened:
+        out.write("Opened your browser to log in to Cogniac.\n")
+    else:
+        out.write("Open the following URL in your browser to log in to Cogniac:\n")
+    out.write("\n    %s\n\n" % auth_url)
+    out.write("Waiting for authentication (Ctrl-C to cancel)...\n")
+    out.flush()
+
+    try:
+        finished = done.wait(timeout)
+    except KeyboardInterrupt:
+        server.shutdown()
+        raise
+    finally:
+        server.shutdown()
+
+    if not finished:
+        raise Exception("Timed out after %d seconds waiting for browser login." % timeout)
+    if 'api_key' not in result:
+        raise Exception(result.get('error', 'login failed'))
+
+    return result['api_key'], url_prefix

--- a/cogniac/auth_login.py
+++ b/cogniac/auth_login.py
@@ -21,6 +21,7 @@ exchange.
 Copyright (C) 2016 Cogniac Corporation.
 """
 
+import html
 import http.server
 import secrets
 import sys
@@ -50,7 +51,7 @@ def _failure_html(reason):
 <h2>Cogniac CLI login failed.</h2>
 <p>%s</p>
 <p>Return to your terminal and try again.</p>
-</body></html>""" % urllib.parse.quote(reason or "unknown error"))
+</body></html>""" % html.escape(reason or "unknown error"))
 
 
 def web_base_url(api_url_prefix):

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -28,6 +28,11 @@ Read commands:
     cogniac version
     cogniac auth
 
+Auth commands:
+    cogniac auth                    # check credentials (env vars or stored login)
+    cogniac auth login [--no-browser]   # browser login; stores per-user API key at ~/.config/cogniac/credentials
+    cogniac auth logout             # remove the stored login credential
+
 Write commands:
     cogniac subjects create <name> [--description D] [--external-id E]
     cogniac subjects associate <subject_uid> <media_id> [--consensus C]
@@ -47,7 +52,11 @@ from importlib.metadata import version as _pkg_version, PackageNotFoundError
 
 from tabulate import tabulate
 
-from .cogniac import CogniacConnection
+from .cogniac import CogniacConnection, DEFAULT_COG_URL_PREFIX
+from .credentials import (
+    stored_api_key, stored_url_prefix, save_credentials,
+    delete_credentials, credentials_path,
+)
 
 try:
     __pkg_version__ = _pkg_version("cogniac")
@@ -485,23 +494,33 @@ def cmd_auth(args):
     also verify that a real session can be minted against it via /1/token."""
     has_api_key = 'COG_API_KEY' in os.environ
     has_user_pass = 'COG_USER' in os.environ and 'COG_PASS' in os.environ
+    has_stored = stored_api_key() is not None
     flag_tenant = getattr(args, 'tenant', None)
     env_tenant = os.environ.get('COG_TENANT')
     effective_tenant = flag_tenant or env_tenant
 
-    if not has_api_key and not has_user_pass:
-        error_exit("AuthError", "No credentials found. Set COG_API_KEY or COG_USER+COG_PASS environment variables.")
+    if not has_api_key and not has_user_pass and not has_stored:
+        error_exit("AuthError", "No credentials found. Run `cogniac auth login`, or set COG_API_KEY or COG_USER+COG_PASS environment variables.")
+
+    if has_api_key:
+        auth_method = "api_key"
+    elif has_user_pass:
+        auth_method = "user_pass"
+    else:
+        auth_method = "stored_login"
 
     result = {
-        "auth_method": "api_key" if has_api_key else "user_pass",
+        "auth_method": auth_method,
         "tenant_set": effective_tenant is not None,
     }
+    if auth_method == "stored_login":
+        result["credentials_path"] = credentials_path()
 
     if effective_tenant:
         result["tenant_id"] = effective_tenant
         result["tenant_source"] = "flag" if flag_tenant else "env"
 
-    url_prefix = os.environ.get('COG_URL_PREFIX', 'https://api.cogniac.io/')
+    url_prefix = os.environ.get('COG_URL_PREFIX') or stored_url_prefix() or DEFAULT_COG_URL_PREFIX
     result["url_prefix"] = url_prefix
     try:
         tenants = CogniacConnection.get_all_authorized_tenants(url_prefix=url_prefix)
@@ -526,6 +545,59 @@ def cmd_auth(args):
             "--tenant <id> (or set COG_TENANT) to work with the specified tenant."
         )
 
+    output(result, args)
+
+
+def cmd_auth_login(args):
+    """Authenticate via the browser (loopback redirect) and store a per-user
+    API key at ~/.config/cogniac/credentials so future invocations need no
+    environment setup."""
+    import datetime
+    import socket
+    from .auth_login import login
+
+    url_prefix = os.environ.get('COG_URL_PREFIX') or stored_url_prefix() or DEFAULT_COG_URL_PREFIX
+    try:
+        api_key, url_prefix = login(url_prefix, open_browser=not getattr(args, 'no_browser', False))
+    except KeyboardInterrupt:
+        error_exit("LoginCancelled", "Login cancelled.")
+    except Exception as e:
+        error_exit("LoginError", str(e))
+
+    try:
+        hostname = socket.gethostname()
+    except Exception:
+        hostname = None
+    label = "cogniac CLI %s %s" % (hostname or "", datetime.date.today().isoformat())
+    path = save_credentials(api_key, url_prefix=url_prefix,
+                            label=label.strip(),
+                            hostname=hostname,
+                            created_at=datetime.datetime.now().isoformat(timespec='seconds'))
+
+    result = {"status": "logged_in", "credentials_path": path, "url_prefix": url_prefix}
+    # Best-effort verification that the freshly-minted key works; report identity if so.
+    try:
+        import httpx
+        resp = httpx.get(url_prefix + "/1/users/current/tenants",
+                         headers={"Authorization": "Key %s" % api_key}, timeout=30,
+                         follow_redirects=True)
+        raise_errors(resp)
+        result["tenant_count"] = len(resp.json().get('tenants', []))
+        result["verified"] = True
+    except Exception as e:
+        result["verified"] = False
+        result["detail"] = str(e)
+    output(result, args)
+
+
+def cmd_auth_logout(args):
+    """Remove the stored login credential."""
+    removed = delete_credentials()
+    result = {
+        "status": "logged_out" if removed else "not_logged_in",
+        "credentials_path": credentials_path(),
+        "removed": removed,
+    }
     output(result, args)
 
 
@@ -765,9 +837,23 @@ def build_parser():
     p.add_argument('workflow_id', help='Workflow ID')
     p.set_defaults(func=cmd_workflows_get)
 
-    # cogniac auth
-    p = subparsers.add_parser('auth', help='Check credentials; if --tenant/COG_TENANT is set, verify a session can be minted')
-    p.set_defaults(func=cmd_auth)
+    # cogniac auth [login|logout]
+    auth_parser = subparsers.add_parser(
+        'auth',
+        help='Check credentials, or log in/out. Bare `cogniac auth` checks credentials; '
+             'if --tenant/COG_TENANT is set, verifies a session can be minted')
+    # bare `cogniac auth` (no subcommand) keeps the existing credential-check behavior
+    auth_parser.set_defaults(func=cmd_auth)
+    auth_sub = auth_parser.add_subparsers(dest='auth_command')
+
+    p = auth_sub.add_parser('login',
+                            help='Log in via the browser and store a per-user API key (~/.config/cogniac/credentials)')
+    p.add_argument('--no-browser', dest='no_browser', action='store_true',
+                   help='Do not auto-open a browser; just print the login URL')
+    p.set_defaults(func=cmd_auth_login)
+
+    p = auth_sub.add_parser('logout', help='Remove the stored login credential')
+    p.set_defaults(func=cmd_auth_logout)
 
     # cogniac user
     p = subparsers.add_parser('user', help='Show current user info and system roles')

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -167,7 +167,7 @@ def cmd_tenant(args):
 
 
 def cmd_tenants(args):
-    url_prefix = os.environ.get('COG_URL_PREFIX', 'https://api.cogniac.io/')
+    url_prefix = os.environ.get('COG_URL_PREFIX') or stored_url_prefix() or DEFAULT_COG_URL_PREFIX
     try:
         result = CogniacConnection.get_all_authorized_tenants(url_prefix=url_prefix)
         fmt = getattr(args, 'format', 'json')

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -13,6 +13,7 @@ import httpx
 import sys
 from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception
 from .common import server_error, raise_errors, CredentialError, credential_error
+from .credentials import stored_api_key, stored_url_prefix
 
 from .app     import CogniacApplication
 from .subject import CogniacSubject
@@ -50,9 +51,13 @@ class CogniacConnection(object):
         """
         return the list of valid tenants for the specified user credentials and url_prefix
         """
-        if 'COG_API_KEY' in os.environ:
+        api_key = os.environ.get('COG_API_KEY')
+        if api_key is None and username is None and password is None:
+            # fall back to a stored `cogniac auth login` credential
+            api_key = stored_api_key()
+        if api_key is not None:
             resp = httpx.get(url_prefix + "/1/users/current/tenants",
-                             headers={"Authorization": "Key %s" % os.environ['COG_API_KEY']})
+                             headers={"Authorization": "Key %s" % api_key})
             raise_errors(resp)
             return resp.json()
 
@@ -62,7 +67,7 @@ class CogniacConnection(object):
                 username = os.environ['COG_USER']
                 password = os.environ['COG_PASS']
             except KeyError:
-                raise Exception("No Cogniac Credentials. Try setting COG_USER and COG_PASS environment.")
+                raise Exception("No Cogniac Credentials. Try setting COG_USER and COG_PASS environment, or run `cogniac auth login`.")
 
         resp = httpx.get(url_prefix + "/1/users/current/tenants", auth=(username, password))
         raise_errors(resp)
@@ -114,21 +119,23 @@ class CogniacConnection(object):
             self.password = password
         elif 'COG_API_KEY' in os.environ:
             self.api_key = os.environ['COG_API_KEY']
+        elif 'COG_USER' in os.environ and 'COG_PASS' in os.environ:
+            self.username = os.environ['COG_USER']
+            self.password = os.environ['COG_PASS']
+        elif stored_api_key() is not None:
+            # fall back to a credential stored by `cogniac auth login`
+            self.api_key = stored_api_key()
         else:
-            # credentials not specified, use environment variables if found
-            try:
-                username = os.environ['COG_USER']
-                password = os.environ['COG_PASS']
-                self.username = username
-                self.password = password
-            except KeyError:
-                raise Exception("No Cogniac Credentials. Specify username and password or set COG_USER, COG_PASS or COG_API_KEY environment variables.")
+            raise Exception("No Cogniac Credentials. Specify username and password, set COG_USER, COG_PASS or COG_API_KEY environment variables, or run `cogniac auth login`.")
 
         self.url_prefix = None
         if url_prefix is not None:
             self.url_prefix = url_prefix
         elif 'COG_URL_PREFIX' in os.environ:
             self.url_prefix = os.environ['COG_URL_PREFIX']
+        elif stored_url_prefix() is not None:
+            # adopt the url_prefix recorded by `cogniac auth login`
+            self.url_prefix = stored_url_prefix()
         else:
             self.url_prefix = DEFAULT_COG_URL_PREFIX
 

--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -52,8 +52,10 @@ class CogniacConnection(object):
         return the list of valid tenants for the specified user credentials and url_prefix
         """
         api_key = os.environ.get('COG_API_KEY')
-        if api_key is None and username is None and password is None:
+        has_env_userpass = 'COG_USER' in os.environ and 'COG_PASS' in os.environ
+        if api_key is None and username is None and password is None and not has_env_userpass:
             # fall back to a stored `cogniac auth login` credential
+            # (only after explicit args and COG_USER/COG_PASS env, per documented precedence)
             api_key = stored_api_key()
         if api_key is not None:
             resp = httpx.get(url_prefix + "/1/users/current/tenants",

--- a/cogniac/credentials.py
+++ b/cogniac/credentials.py
@@ -1,0 +1,98 @@
+"""
+On-disk credential store for the Cogniac CLI/SDK.
+
+`cogniac auth login` writes a tenant-less, per-user API key here so that
+subsequent CLI/SDK invocations authenticate with no environment setup. The
+store lives at ``$XDG_CONFIG_HOME/cogniac/credentials`` (default
+``~/.config/cogniac/credentials``) and is written 0600.
+
+This file is consumed as the lowest-precedence credential source: explicit
+constructor arguments and the ``COG_*`` environment variables always win, so a
+user can override the stored login at any time without logging out.
+
+Copyright (C) 2016 Cogniac Corporation.
+"""
+
+import json
+import os
+import stat
+
+DEFAULT_COG_URL_PREFIX = "https://api.cogniac.io/"
+
+
+def config_dir():
+    """Return the cogniac config directory path (honoring XDG_CONFIG_HOME)."""
+    base = os.environ.get('XDG_CONFIG_HOME') or os.path.join(os.path.expanduser('~'), '.config')
+    return os.path.join(base, 'cogniac')
+
+
+def credentials_path():
+    """Return the path to the on-disk credentials file."""
+    return os.path.join(config_dir(), 'credentials')
+
+
+def load_credentials():
+    """Return the stored credentials dict, or None if no (readable) store exists."""
+    path = credentials_path()
+    try:
+        with open(path, 'r') as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or not data.get('api_key'):
+        return None
+    return data
+
+
+def stored_api_key():
+    """Return the stored API key, or None if there is no stored credential."""
+    creds = load_credentials()
+    return creds.get('api_key') if creds else None
+
+
+def stored_url_prefix():
+    """Return the url_prefix associated with the stored credential, or None."""
+    creds = load_credentials()
+    return creds.get('url_prefix') if creds else None
+
+
+def save_credentials(api_key, url_prefix=None, **extra):
+    """Persist an API key (0600) and return the file path.
+
+    Extra keyword fields (e.g. label, created_at, hostname) are stored
+    alongside for diagnostics/management.
+    """
+    d = config_dir()
+    os.makedirs(d, mode=0o700, exist_ok=True)
+    path = credentials_path()
+    data = {"api_key": api_key}
+    if url_prefix:
+        data["url_prefix"] = url_prefix
+    data.update(extra)
+
+    # Write to a temp file then rename so we never expose a partial/world-readable file.
+    tmp = path + ".tmp"
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    os.replace(tmp, path)
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    return path
+
+
+def delete_credentials():
+    """Remove the stored credential file. Returns True if a file was removed."""
+    path = credentials_path()
+    try:
+        os.unlink(path)
+        return True
+    except FileNotFoundError:
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cogniac"
-version = "3.0.5"
+version = "3.1.0"
 description = "Python SDK for Cogniac Public API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "2026-06-02T07:00:00Z"
+
 [[package]]
 name = "anyio"
 version = "4.13.0"
@@ -26,7 +29,7 @@ wheels = [
 
 [[package]]
 name = "cogniac"
-version = "3.0.4"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Contributes to: Cogniac/CloudCore-Product#1026

Implements the **CLI/SDK side** of the browser-loopback login flow — the RFC 8252 "loopback redirect" pattern used by `gh auth login`, `gcloud auth login`, and `aws sso login`. After one browser round-trip the CLI is authenticated with no manual API-key handling. This is **Phase 1 (MVP)**: `state` CSRF guard, key-in-query, on-disk config store, **no backend changes**.

## What's new

- **`cogniac auth login [--no-browser]`** — binds `127.0.0.1:<random port>`, generates a `state` token, opens the browser at `<web>/app/cli-auth?port=&state=`, catches the `/cb?code=&state=` loopback redirect, verifies `state`, and stores the minted per-user API key. Mints/stores/verifies the fresh key directly and **never prints it**.
- **`cogniac auth logout`** — removes the stored credential.
- Bare **`cogniac auth`** keeps its existing check behavior and now recognizes a `stored_login` source.

## New modules

- **`cogniac/credentials.py`** — XDG-aware on-disk store at `~/.config/cogniac/credentials`, written `0600` via temp-file-then-rename (never exposes a partial/world-readable file).
- **`cogniac/auth_login.py`** — stdlib loopback listener + `state` CSRF guard + the shared frontend contract. `web_base_url()` derives the web origin from the API prefix: strips an explicit `api.` subdomain (prod `api.cogniac.io`→`cogniac.io`) while leaving same-host staging/on-prem untouched. The CLI opens the one URL both the Ember and React consent pages serve, so it's frontend-agnostic.

## Wiring

- `cogniac.py` & `async_connection.py`: stored login added as the **lowest-precedence** credential source (explicit args → `COG_API_KEY` → `COG_USER`/`COG_PASS` → stored login). The stored `url_prefix` is adopted when none is set explicitly; `get_all_authorized_tenants` also falls back to the stored key.
- `pyproject.toml`: `3.0.5` → `3.1.0`.
- `CLAUDE.md`: documents the credential precedence/source and new auth commands.

## Companion work (separate)

- Ember consent page → Cogniac/web-app#6317
- React consent page → Cogniac/web-app-react#2746
- Phase 2 (PKCE + `POST /1/cli/token` one-time-code exchange) left for the hardening pass.

## Testing

Verified locally: store round-trip (`0600` confirmed), full loopback happy path, `state`-mismatch rejection, `auth logout`/`auth` JSON output, parser routing for all `auth` subcommands, clean import + 79-test collection. (Integration tests require a live tenant and were not run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)