### PR TITLE
normalize app_data/custom_data JSON strings in SDK responses

### DIFF
--- a/cogniac/async_subject.py
+++ b/cogniac/async_subject.py
@@ -4,7 +4,7 @@ Async CogniacSubject Object Client
 Copyright (C) 2016 Cogniac Corporation
 """
 
-from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error, raise_errors
+from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error, raise_errors, parse_json_str
 
 
 class AsyncCogniacSubject(object):
@@ -347,6 +347,10 @@ class AsyncCogniacSubject(object):
         while url:
             resp = await get_next(url)
             for sma in resp['data']:
+                if isinstance(sma.get('subject'), dict):
+                    sma['subject']['app_data'] = parse_json_str(sma['subject'].get('app_data'))
+                if isinstance(sma.get('media'), dict):
+                    sma['media']['custom_data'] = parse_json_str(sma['media'].get('custom_data'))
                 yield sma
                 count += 1
                 if limit and count == limit:

--- a/cogniac/common.py
+++ b/cogniac/common.py
@@ -4,6 +4,8 @@ Cogniac API common definitions
 Copyright (C) 2016 Cogniac Corporation
 """
 
+import json
+
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
 from httpx import ConnectError
 
@@ -39,6 +41,22 @@ def credential_error(exception):
 def server_error(exception):
     """Return True if we should retry (in this case when it's an ServerError, False otherwise"""
     return isinstance(exception, ServerError) or isinstance(exception, ConnectError)
+
+
+def parse_json_str(val):
+    """Return val parsed as JSON if it's a string, otherwise return it unchanged.
+
+    The API occasionally serializes app_data and custom_data as JSON strings
+    instead of inline objects. Callers should not need to guard for this.
+    Non-string values (dict, list, None) are passed through untouched.
+    A string that is not valid JSON is also returned as-is.
+    """
+    if isinstance(val, str):
+        try:
+            return json.loads(val)
+        except (ValueError, TypeError):
+            pass
+    return val
 
 
 def raise_errors(response):

--- a/cogniac/media.py
+++ b/cogniac/media.py
@@ -378,7 +378,11 @@ class CogniacMedia(object):
             url += "?wait_capture_id=%s" % wait_capture_id
 
         resp = self._cc._get(url)
-        return resp.json()['detections']
+        detections = resp.json()['detections']
+        for d in detections:
+            if 'app_data' in d:
+                d['app_data'] = parse_json_str(d['app_data'])
+        return detections
 
     ##
     #  subjects
@@ -413,4 +417,10 @@ class CogniacMedia(object):
                          }
         """
         resp = self._cc._get("/1/media/%s/subjects" % (self.media_id))
-        return resp.json()['data']
+        data = resp.json()['data']
+        for item in data:
+            if isinstance(item.get('subject'), dict):
+                item['subject']['app_data'] = parse_json_str(item['subject'].get('app_data'))
+            if isinstance(item.get('media'), dict):
+                item['media']['custom_data'] = parse_json_str(item['media'].get('custom_data'))
+        return data

--- a/cogniac/subject.py
+++ b/cogniac/subject.py
@@ -493,6 +493,10 @@ class CogniacSubject(object):
         while url:
             resp = get_next(url)
             for sma in resp['data']:
+                if isinstance(sma.get('subject'), dict):
+                    sma['subject']['app_data'] = parse_json_str(sma['subject'].get('app_data'))
+                if isinstance(sma.get('media'), dict):
+                    sma['media']['custom_data'] = parse_json_str(sma['media'].get('custom_data'))
                 yield sma
                 count += 1
                 if limit and count == limit:

--- a/tests/test_json_normalization.py
+++ b/tests/test_json_normalization.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for app_data / custom_data JSON-string normalization (issue #157).
+
+These tests do NOT require live credentials — they mock the HTTP layer.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from cogniac.common import parse_json_str
+from cogniac.subject import CogniacSubject
+
+
+# ---------------------------------------------------------------------------
+# parse_json_str unit tests
+# ---------------------------------------------------------------------------
+
+class TestParseJsonStr:
+
+    def test_dict_passthrough(self):
+        val = {"key": "value", "num": 42}
+        assert parse_json_str(val) is val
+
+    def test_list_passthrough(self):
+        val = [1, 2, 3]
+        assert parse_json_str(val) is val
+
+    def test_none_passthrough(self):
+        assert parse_json_str(None) is None
+
+    def test_int_passthrough(self):
+        assert parse_json_str(42) == 42
+
+    def test_string_dict_parsed(self):
+        s = '{"score": 0.95, "class": "defect"}'
+        result = parse_json_str(s)
+        assert result == {"score": 0.95, "class": "defect"}
+
+    def test_string_list_parsed(self):
+        s = '[1, 2, 3]'
+        assert parse_json_str(s) == [1, 2, 3]
+
+    def test_invalid_json_string_returned_as_is(self):
+        s = "not valid json"
+        assert parse_json_str(s) == s
+
+    def test_empty_string_returned_as_is(self):
+        assert parse_json_str("") == ""
+
+
+# ---------------------------------------------------------------------------
+# media_associations normalization integration test
+# ---------------------------------------------------------------------------
+
+def _make_subject(cc):
+    """Build a CogniacSubject without a live API call."""
+    data = {
+        "subject_uid": "test-uid-001",
+        "name": "test-subject",
+        "tenant_id": "test-tenant",
+    }
+    return CogniacSubject(cc, data)
+
+
+def _mock_response(payload):
+    resp = MagicMock()
+    resp.json.return_value = payload
+    return resp
+
+
+class TestMediaAssociationsNormalization:
+
+    def _make_page(self, app_data, custom_data=None):
+        return {
+            "data": [{
+                "subject": {
+                    "media_id": "m001",
+                    "subject_uid": "test-uid-001",
+                    "probability": 0.9,
+                    "app_data_type": "box",
+                    "app_data": app_data,
+                },
+                "media": {
+                    "media_id": "m001",
+                    "custom_data": custom_data,
+                },
+                "focus": None,
+            }],
+            "paging": {},
+        }
+
+    def test_app_data_string_is_parsed(self):
+        cc = MagicMock()
+        subject = _make_subject(cc)
+
+        app_data_dict = {"score": 0.95, "boxes": [{"x0": 10, "y0": 20, "x1": 100, "y1": 200}]}
+        page = self._make_page(app_data=json.dumps(app_data_dict))
+        cc._get.return_value = _mock_response(page)
+
+        assocs = list(subject.media_associations(limit=1))
+        assert len(assocs) == 1
+        result = assocs[0]["subject"]["app_data"]
+        assert isinstance(result, dict), f"Expected dict, got {type(result)}: {result!r}"
+        assert result == app_data_dict
+
+    def test_app_data_dict_is_unchanged(self):
+        cc = MagicMock()
+        subject = _make_subject(cc)
+
+        app_data_dict = {"score": 0.9}
+        page = self._make_page(app_data=app_data_dict)
+        cc._get.return_value = _mock_response(page)
+
+        assocs = list(subject.media_associations(limit=1))
+        assert assocs[0]["subject"]["app_data"] == app_data_dict
+
+    def test_app_data_none_is_unchanged(self):
+        cc = MagicMock()
+        subject = _make_subject(cc)
+
+        page = self._make_page(app_data=None)
+        cc._get.return_value = _mock_response(page)
+
+        assocs = list(subject.media_associations(limit=1))
+        assert assocs[0]["subject"]["app_data"] is None
+
+    def test_custom_data_string_is_parsed(self):
+        cc = MagicMock()
+        subject = _make_subject(cc)
+
+        custom = {"tag": "batch-A", "run": 7}
+        page = self._make_page(app_data=None, custom_data=json.dumps(custom))
+        cc._get.return_value = _mock_response(page)
+
+        assocs = list(subject.media_associations(limit=1))
+        result = assocs[0]["media"]["custom_data"]
+        assert isinstance(result, dict)
+        assert result == custom


### PR DESCRIPTION
## What

Fixes #157: `app_data` (on subject-media associations and detections) and `custom_data` (on media objects) are occasionally returned by the API as serialized JSON strings rather than inline dicts/lists. Every caller currently needs a guard like:

```python
ad = rec['subject']['app_data']
if isinstance(ad, str):
    ad = json.loads(ad)
```

This PR moves that normalization into the SDK so callers always receive parsed Python objects.

## Changes

- **`cogniac/common.py`** — adds `parse_json_str(val)`: returns `json.loads(val)` if val is a string that parses as JSON, passes everything else through unchanged.
- **`cogniac/subject.py`** — normalizes `sma['subject']['app_data']` and `sma['media']['custom_data']` before each `yield` in `media_associations()`.
- **`cogniac/async_subject.py`** — same for the async generator.
- **`cogniac/media.py`** — normalizes `app_data` in `detections()` and `subjects()` return values.
- **`tests/test_json_normalization.py`** — 12 unit tests (no live credentials required): 8 for `parse_json_str` edge cases, 4 integration tests mocking the HTTP layer in `media_associations()`.

## Test

```
12 passed in 0.02s
```

Refs Cogniac/CloudCore-Product#996