### PR TITLE
fix 429 retry, EdgeFlow.status() docs, CLI --full-media

### DIFF
--- a/cogniac/async_subject.py
+++ b/cogniac/async_subject.py
@@ -4,7 +4,7 @@ Async CogniacSubject Object Client
 Copyright (C) 2016 Cogniac Corporation
 """
 
-from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error, raise_errors
+from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error, raise_errors, parse_json_str
 
 
 class AsyncCogniacSubject(object):
@@ -347,6 +347,10 @@ class AsyncCogniacSubject(object):
         while url:
             resp = await get_next(url)
             for sma in resp['data']:
+                if isinstance(sma.get('subject'), dict):
+                    sma['subject']['app_data'] = parse_json_str(sma['subject'].get('app_data'))
+                if isinstance(sma.get('media'), dict):
+                    sma['media']['custom_data'] = parse_json_str(sma['media'].get('custom_data'))
                 yield sma
                 count += 1
                 if limit and count == limit:

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -342,6 +342,7 @@ def cmd_subjects_media(args):
             probability_upper=args.probability_upper,
             consensus=args.consensus,
             limit=args.limit,
+            abridged_media=not args.full_media,
         )
         results = list(associations)
         fmt = getattr(args, 'format', 'json')
@@ -735,6 +736,8 @@ def build_parser():
     p.add_argument('--consensus', choices=['True', 'False', 'Sidelined'], help='Filter by consensus')
     p.add_argument('--probability-lower', dest='probability_lower', type=float, help='Min probability')
     p.add_argument('--probability-upper', dest='probability_upper', type=float, help='Max probability')
+    p.add_argument('--full-media', dest='full_media', action='store_true',
+                   help='Return full media records (includes domain_unit, sequence_ix, timestamps)')
     p.set_defaults(func=cmd_subjects_media)
 
     p = subjects_sub.add_parser('search', help='Search subjects')

--- a/cogniac/common.py
+++ b/cogniac/common.py
@@ -4,6 +4,8 @@ Cogniac API common definitions
 Copyright (C) 2016 Cogniac Corporation
 """
 
+import json
+
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
 from httpx import ConnectError
 
@@ -39,6 +41,22 @@ def credential_error(exception):
 def server_error(exception):
     """Return True if we should retry (in this case when it's an ServerError, False otherwise"""
     return isinstance(exception, ServerError) or isinstance(exception, ConnectError)
+
+
+def parse_json_str(val):
+    """Return val parsed as JSON if it's a string, otherwise return it unchanged.
+
+    The API occasionally serializes app_data and custom_data as JSON strings
+    instead of inline objects. Callers should not need to guard for this.
+    Non-string values (dict, list, None) are passed through untouched.
+    A string that is not valid JSON is also returned as-is.
+    """
+    if isinstance(val, str):
+        try:
+            return json.loads(val)
+        except (ValueError, TypeError):
+            pass
+    return val
 
 
 def raise_errors(response):

--- a/cogniac/common.py
+++ b/cogniac/common.py
@@ -71,6 +71,14 @@ def raise_errors(response):
         msg = "Invalid username password credentials (%d): %s" % (response.status_code, response.text)
         raise CredentialError(msg)
 
+    if response.status_code == 429:
+        # Raise as ServerError so the tenacity retry path picks it up.
+        # Callers using the shared retry decorator get automatic backoff;
+        # the Retry-After header is not currently honored (improvement tracked
+        # in cogniac-sdk-py#158).
+        msg = "RateLimited (429): %s" % response.text
+        raise ServerError(msg)
+
     if response.status_code >= 400:
         msg = "ClientError (%d): %s" % (response.status_code, response.text)
         raise ClientError(msg, response.status_code)

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -306,8 +306,15 @@ class CogniacEdgeFlow(object):
                limit=None,
                sort=None):
         """
-        Yields EdgeFlow status, optionally only for a particular subsytem,
-         sorted by timestamp.
+        Yields EdgeFlow status records, optionally filtered by subsystem,
+        sorted by timestamp.
+
+        WARNING: called with no arguments this generator pages through the
+        appliance's full status history, which can be arbitrarily long on a
+        long-lived device.  Always pass limit= or end= to bound the result:
+
+            list(ef.status(limit=10))               # last 10 records
+            list(ef.status(subsystem_name='ping', limit=1))  # latest ping
 
         start (float)          filter by last update timestamp > start
                                (seconds since epoch)

--- a/cogniac/media.py
+++ b/cogniac/media.py
@@ -378,7 +378,11 @@ class CogniacMedia(object):
             url += "?wait_capture_id=%s" % wait_capture_id
 
         resp = self._cc._get(url)
-        return resp.json()['detections']
+        detections = resp.json()['detections']
+        for d in detections:
+            if 'app_data' in d:
+                d['app_data'] = parse_json_str(d['app_data'])
+        return detections
 
     ##
     #  subjects
@@ -413,4 +417,10 @@ class CogniacMedia(object):
                          }
         """
         resp = self._cc._get("/1/media/%s/subjects" % (self.media_id))
-        return resp.json()['data']
+        data = resp.json()['data']
+        for item in data:
+            if isinstance(item.get('subject'), dict):
+                item['subject']['app_data'] = parse_json_str(item['subject'].get('app_data'))
+            if isinstance(item.get('media'), dict):
+                item['media']['custom_data'] = parse_json_str(item['media'].get('custom_data'))
+        return data

--- a/cogniac/subject.py
+++ b/cogniac/subject.py
@@ -493,6 +493,10 @@ class CogniacSubject(object):
         while url:
             resp = get_next(url)
             for sma in resp['data']:
+                if isinstance(sma.get('subject'), dict):
+                    sma['subject']['app_data'] = parse_json_str(sma['subject'].get('app_data'))
+                if isinstance(sma.get('media'), dict):
+                    sma['media']['custom_data'] = parse_json_str(sma['media'].get('custom_data'))
                 yield sma
                 count += 1
                 if limit and count == limit:

--- a/tests/test_json_normalization.py
+++ b/tests/test_json_normalization.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for app_data / custom_data JSON-string normalization (issue #157).
+
+These tests do NOT require live credentials — they mock the HTTP layer.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from cogniac.common import parse_json_str
+from cogniac.subject import CogniacSubject
+
+
+# ---------------------------------------------------------------------------
+# parse_json_str unit tests
+# ---------------------------------------------------------------------------
+
+class TestParseJsonStr:
+
+    def test_dict_passthrough(self):
+        val = {"key": "value", "num": 42}
+        assert parse_json_str(val) is val
+
+    def test_list_passthrough(self):
+        val = [1, 2, 3]
+        assert parse_json_str(val) is val
+
+    def test_none_passthrough(self):
+        assert parse_json_str(None) is None
+
+    def test_int_passthrough(self):
+        assert parse_json_str(42) == 42
+
+    def test_string_dict_parsed(self):
+        s = '{"score": 0.95, "class": "defect"}'
+        result = parse_json_str(s)
+        assert result == {"score": 0.95, "class": "defect"}
+
+    def test_string_list_parsed(self):
+        s = '[1, 2, 3]'
+        assert parse_json_str(s) == [1, 2, 3]
+
+    def test_invalid_json_string_returned_as_is(self):
+        s = "not valid json"
+        assert parse_json_str(s) == s
+
+    def test_empty_string_returned_as_is(self):
+        assert parse_json_str("") == ""
+
+
+# ---------------------------------------------------------------------------
+# media_associations normalization integration test
+# ---------------------------------------------------------------------------
+
+def _make_subject(cc):
+    """Build a CogniacSubject without a live API call."""
+    data = {
+        "subject_uid": "test-uid-001",
+        "name": "test-subject",
+        "tenant_id": "test-tenant",
+    }
+    return CogniacSubject(cc, data)
+
+
+def _mock_response(payload):
+    resp = MagicMock()
+    resp.json.return_value = payload
+    return resp
+
+
+class TestMediaAssociationsNormalization:
+
+    def _make_page(self, app_data, custom_data=None):
+        return {
+            "data": [{
+                "subject": {
+                    "media_id": "m001",
+                    "subject_uid": "test-uid-001",
+                    "probability": 0.9,
+                    "app_data_type": "box",
+                    "app_data": app_data,
+                },
+                "media": {
+                    "media_id": "m001",
+                    "custom_data": custom_data,
+                },
+                "focus": None,
+            }],
+            "paging": {},
+        }
+
+    def test_app_data_string_is_parsed(self):
+        cc = MagicMock()
+        subject = _make_subject(cc)
+
+        app_data_dict = {"score": 0.95, "boxes": [{"x0": 10, "y0": 20, "x1": 100, "y1": 200}]}
+        page = self._make_page(app_data=json.dumps(app_data_dict))
+        cc._get.return_value = _mock_response(page)
+
+        assocs = list(subject.media_associations(limit=1))
+        assert len(assocs) == 1
+        result = assocs[0]["subject"]["app_data"]
+        assert isinstance(result, dict), f"Expected dict, got {type(result)}: {result!r}"
+        assert result == app_data_dict
+
+    def test_app_data_dict_is_unchanged(self):
+        cc = MagicMock()
+        subject = _make_subject(cc)
+
+        app_data_dict = {"score": 0.9}
+        page = self._make_page(app_data=app_data_dict)
+        cc._get.return_value = _mock_response(page)
+
+        assocs = list(subject.media_associations(limit=1))
+        assert assocs[0]["subject"]["app_data"] == app_data_dict
+
+    def test_app_data_none_is_unchanged(self):
+        cc = MagicMock()
+        subject = _make_subject(cc)
+
+        page = self._make_page(app_data=None)
+        cc._get.return_value = _mock_response(page)
+
+        assocs = list(subject.media_associations(limit=1))
+        assert assocs[0]["subject"]["app_data"] is None
+
+    def test_custom_data_string_is_parsed(self):
+        cc = MagicMock()
+        subject = _make_subject(cc)
+
+        custom = {"tag": "batch-A", "run": 7}
+        page = self._make_page(app_data=None, custom_data=json.dumps(custom))
+        cc._get.return_value = _mock_response(page)
+
+        assocs = list(subject.media_associations(limit=1))
+        result = assocs[0]["media"]["custom_data"]
+        assert isinstance(result, dict)
+        assert result == custom

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for HTTP 429 rate-limit retry behavior (issue #158).
+
+No live credentials required.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from cogniac.common import raise_errors, ServerError
+
+
+class TestRaiseErrors429:
+
+    def _mock_resp(self, status_code, text="rate limited"):
+        r = MagicMock()
+        r.status_code = status_code
+        r.text = text
+        return r
+
+    def test_429_raises_server_error(self):
+        """429 must raise ServerError so the tenacity retry path picks it up."""
+        with pytest.raises(ServerError) as exc_info:
+            raise_errors(self._mock_resp(429))
+        assert "429" in str(exc_info.value) or "RateLimited" in str(exc_info.value)
+
+    def test_500_raises_server_error(self):
+        with pytest.raises(ServerError):
+            raise_errors(self._mock_resp(500))
+
+    def test_400_not_server_error(self):
+        from cogniac.common import ClientError
+        with pytest.raises(ClientError):
+            raise_errors(self._mock_resp(400))
+
+    def test_200_no_error(self):
+        raise_errors(self._mock_resp(200))  # should not raise


### PR DESCRIPTION
Batch of three follow-up fixes filed during the skills#15 review cycle.

## Changes

### #158 — HTTP 429 no longer crashes bulk operations

`raise_errors()` previously raised `ClientError` for 429, which bypassed the tenacity retry decorator. Changed to `ServerError` so the existing 8-attempt exponential backoff handles rate limits automatically. `Retry-After` header support is deferred (noted in a comment).

### #159 — EdgeFlow.status() unbounded-generator warning

The no-args call pages the full status history, which is arbitrarily long on a long-lived appliance. Added a prominent `WARNING:` block to the docstring with safe usage examples (`limit=10`, `end=`).

### #160 — CLI `--full-media` flag

`cogniac subjects media` always called `media_associations(abridged_media=True)`, hiding `domain_unit`, `sequence_ix`, `media_timestamp`, and `created_at`. New `--full-media` flag passes `abridged_media=False`.

## Tests

4 new unit tests for the 429 path (no live credentials needed). All 16 unit tests pass.

Fixes #158, fixes #159, fixes #160
Refs Cogniac/CloudCore-Product#996