### PR TITLE
Fix _get/_head to support a request body (httpx migration regression)

### DIFF
--- a/cogniac/cogniac.py
+++ b/cogniac/cogniac.py
@@ -263,7 +263,8 @@ class CogniacConnection(object):
         if timeout is None:
             timeout = self.timeout
         try:
-            resp = self.session.head(url, timeout=timeout, **kwargs)
+            # use request() instead of head() to support a data/json/content body
+            resp = self.session.request('HEAD', url, timeout=timeout, **kwargs)
             raise_errors(resp)
         except CredentialError:
             self.__authenticate()
@@ -286,7 +287,8 @@ class CogniacConnection(object):
             timeout = self.timeout
         kwargs.pop('stream', None)  # httpx handles streaming differently
         try:
-            resp = self.session.get(url, timeout=timeout, **kwargs)
+            # use request() instead of get() to support a data/json/content body
+            resp = self.session.request('GET', url, timeout=timeout, **kwargs)
             raise_errors(resp)
         except CredentialError:
             self.__authenticate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cogniac"
-version = "3.1.0"
+version = "3.1.1"
 description = "Python SDK for Cogniac Public API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -1,0 +1,33 @@
+"""
+Regression tests for request-body support on _get / _head.
+
+cogniac 3.x migrated the HTTP client from requests to httpx. httpx's
+Client.get()/head() convenience methods do not accept a request body, but the
+SDK must still support GET/HEAD-with-body (the requests-era behavior) because
+callers such as cogtrain issue GET-with-body requests (e.g. OptunaStorage).
+_get/_head therefore route through session.request(), matching _delete.
+"""
+
+import pytest
+from tests.conftest import requires_live
+
+
+@requires_live
+class TestRequestBodySupport:
+
+    def test_get_accepts_request_body(self, cc):
+        # Pre-fix this raised
+        # "TypeError: Client.get() got an unexpected keyword argument 'data'".
+        resp = cc._get("/1/users/current", data={"data": "{}"})
+        assert resp.status_code == 200
+
+    def test_head_accepts_request_body(self, cc):
+        # _head has the same httpx limitation; it must not reject a body kwarg.
+        try:
+            cc._head("/1/users/current", data={"data": "{}"})
+        except TypeError as exc:
+            pytest.fail(f"_head must accept a request body: {exc}")
+        except Exception:
+            # A non-2xx status (e.g. 405) is acceptable here; only the
+            # TypeError on the body kwarg is the regression we guard against.
+            pass


### PR DESCRIPTION
## Problem

Since the `requests` -> `httpx` migration in **3.0.0**, `_get` and `_head` call `httpx.Client.get()` / `.head()`. Unlike `requests`, those httpx convenience methods do **not** accept a request body. Any caller that issues a GET/HEAD with a body breaks with:

```
TypeError: Client.get() got an unexpected keyword argument 'data'
```

This breaks **cogtrain** (and any other GET-with-body consumer): e.g. `OptunaStorage` calls `cc._get(".../optuna/get_study_name_from_id", data={"data": json.dumps(...)})`, which kills HPO training at `get_study_trial`. The same pattern exists across `OptunaStorage` (7 calls), `HpoTraining`, `HpoModel`, and `InferenceBaseRuntime`.

## Root cause

The migration already converted `_delete` to `self.session.request('DELETE', ...)` (with the comment "use request() instead of delete() to support json/content body"), but `_get` and `_head` were missed and kept using the convenience methods. `httpx.Client.request(...)` accepts `data`/`content`/`json`; the convenience `.get()/.head()` do not.

## Fix

Route `_get` and `_head` through `self.session.request('GET'/'HEAD', ...)`, mirroring `_delete`. Behavior for bodiless GET/HEAD is unchanged (`.get()` is just `request('GET', ...)` internally; the client already sets `follow_redirects=True`). This is the last piece of the requests->httpx migration.

## Validation

- Added `tests/test_request_body.py` (live `@requires_live` regression test for GET/HEAD-with-body). Both tests pass against the live API.
- Verified against real CloudCore optuna endpoints: `request('GET', ..., data=...)` returns **200** on all 6 GET-with-body OptunaStorage endpoints (`get_study_name_from_id`, `get_study_id_from_name`, `get_study_directions`, `get_study_user_attrs`, `get_study_system_attrs`, `get_all_trials`) -- confirmed these require the payload in the **body** (server returns `400 {"loc":["body","data"]}` if sent as a query param).

## Context

This is a `requests`->`httpx` regression introduced in 3.0.0 (2026-05-20); 2.x handled GET-with-body fine. As an interim unblock, `hpogc-yolo-pytorch` pinned `cogniac<3` (Cogniac/hpogc-yolo-pytorch#85). Once this lands and a fixed 3.x is released, that pin can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)