### PR TITLE
SDK/CLI coverage follow-ups: async normalization parity, error-type mapping, README, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ for detection in app.detections(limit=100):
 | `CogniacMedia` | Image and video files |
 | `CogniacTenant` | Tenant (organization) management |
 | `CogniacUser` | User accounts and API keys |
-| `CogniacEdgeFlow` | Edge computing devices |
+| `CogniacEdgeFlow` | Edge computing devices (alias: `CogniacGateway`) |
 | `CogniacNetworkCamera` | Network camera configuration |
 | `CogniacExternalResult` | External inspection results |
 | `CogniacOpsReview` | Operations review queue |
+| `CogniacDeployment` | Deployment groups (EdgeFlow/CloudFlow rollouts) |
+| `CogniacDeploymentCapacityClass` | Deployment capacity classes |
+| `CogniacWorkflow` | Deployment workflows and versions |
+| `CogniacBuild` | EdgeFlow/CloudFlow build definitions |
 
 ## Async API
 
@@ -117,20 +121,26 @@ Every sync entity class has an async counterpart prefixed with `Async` (e.g., `A
 
 ### `cogniac`
 
-Agent-friendly CLI with JSON output (default) or `--format table`.
+Agent-friendly CLI. JSON output by default; `--format table` for humans or `--format jsonl` for one JSON object per line. The command tree is **nested, noun-first / verb-last**; resource ids are `--<resource>-id` flags (the older positional form, e.g. `application get <id>`, still works). `--format` and `--tenant` may be given before or after the command.
 
 ```bash
-cogniac auth                            # check credentials (add --tenant <id> to verify a session)
-cogniac tenant                          # current tenant info
-cogniac apps list                       # list applications
-cogniac apps leaderboard <id>           # ranked candidate-model snapshot
-cogniac apps eval-metrics <id>          # active evaluation metrics
-cogniac subjects list                   # list subjects
-cogniac subjects search --prefix test   # search subjects
-cogniac media get <media_id>            # get media metadata
-cogniac media download <media_id> -o f  # download media to file
-cogniac edgeflows list                  # list edge devices
+cogniac auth                                       # check credentials (add --tenant <id> to verify a session)
+cogniac auth login                                 # browser login; store a per-user API key
+cogniac commands                                   # print the whole command tree as JSON (noun -> verbs -> args)
+
+cogniac tenant get                                 # current tenant info
+cogniac application list                           # list applications
+cogniac application get --application-id <id>      # one application
+cogniac subject list
+cogniac subject search --prefix test               # search subjects
+cogniac subject media --subject-uid <uid> --full-media   # full media records, not just media_id
+cogniac media get --media-id <id>                  # media metadata
+cogniac media download --media-id <id> -o out.jpg  # download media to file
+cogniac edgeflow list                              # list edge devices
+cogniac application create --body @app.json        # --body takes inline JSON, @FILE, or - (stdin)
 ```
+
+Run `cogniac <noun> --help` to explore the tree interactively, or `cogniac commands` for the full machine-readable catalog. An unknown command suggests the closest match.
 
 ### `icogniac`
 

--- a/cogniac/async_media.py
+++ b/cogniac/async_media.py
@@ -5,7 +5,7 @@ Copyright (C) 2016-2022 Cogniac Corporation
 """
 
 import asyncio
-from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error, raise_errors
+from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error, raise_errors, parse_json_str
 from .media import file_creation_time
 from hashlib import md5
 from os import stat, fstat, path, SEEK_END
@@ -410,7 +410,11 @@ class AsyncCogniacMedia(object):
             url += "?wait_capture_id=%s" % wait_capture_id
 
         resp = await self._cc._get(url)
-        return resp.json()['detections']
+        detections = resp.json()['detections']
+        for d in detections:
+            if 'app_data' in d:
+                d['app_data'] = parse_json_str(d['app_data'])
+        return detections
 
     ##
     #  subjects
@@ -421,7 +425,13 @@ class AsyncCogniacMedia(object):
         Return a list of subject associations for this media.
         """
         resp = await self._cc._get("/1/media/%s/subjects" % (self.media_id))
-        return resp.json()['data']
+        data = resp.json()['data']
+        for item in data:
+            if isinstance(item.get('subject'), dict):
+                item['subject']['app_data'] = parse_json_str(item['subject'].get('app_data'))
+            if isinstance(item.get('media'), dict):
+                item['media']['custom_data'] = parse_json_str(item['media'].get('custom_data'))
+        return data
 
     ##
     #  share

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -235,13 +235,17 @@ def _truncate(s, maxlen):
     return s if len(s) <= maxlen else s[:maxlen - 3] + '...'
 
 
-# legacy error-type label -> structured envelope "type"
+# error_exit's string label -> structured envelope "type"
 _ERROR_TYPES = {
     'CredentialError': 'auth',
+    'AuthError': 'auth',
+    'LoginError': 'auth',
+    'LoginCancelled': 'auth',
     'ClientError': 'client',
+    'BadRequest': 'client',
+    'UsageError': 'client',
     'ServerError': 'server',
     'ConnectionError': 'connection',
-    'BadRequest': 'client',
 }
 _ERROR_HINTS = {
     'auth': "check COG_API_KEY / COG_USER+COG_PASS, or run 'cogniac auth login'",

--- a/tests/test_coverage_smoke.py
+++ b/tests/test_coverage_smoke.py
@@ -22,7 +22,7 @@ import pytest
 import cogniac
 from cogniac.cli import (build_parser, resource_aliases, _SYNONYM_GROUPS, _resolve_positional_ids,
                          error_exit, output, _command_catalog, _timestamp, _body_arg)
-from cogniac.common import server_error, ClientError, ServerError
+from cogniac.common import server_error, raise_errors, ClientError, ServerError
 
 
 # ---------------------------------------------------------------------------
@@ -748,8 +748,53 @@ def test_server_error_retries_429_not_other_4xx():
     assert server_error(ClientError('bad request', 400)) is False
 
 
+def test_raise_errors_429_raises_retryable_with_retry_after():
+    class _Resp:
+        status_code = 429
+        text = '{"message": "slow down"}'
+        headers = {'Retry-After': '7'}
+
+    with pytest.raises(ClientError) as exc:
+        raise_errors(_Resp())
+    assert exc.value.status_code == 429
+    assert getattr(exc.value, 'retry_after', None) == 7.0
+    assert server_error(exc.value) is True            # 429 is retryable
+
+
+def test_raise_errors_429_without_retry_after_header():
+    class _Resp:
+        status_code = 429
+        text = 'rate limited'
+        headers = {}
+
+    with pytest.raises(ClientError) as exc:
+        raise_errors(_Resp())
+    assert exc.value.status_code == 429
+    assert getattr(exc.value, 'retry_after', None) is None
+
+
 # app_data/custom_data JSON-string normalization (#157) is implemented by
-# common.parse_json_str and covered by tests/test_json_normalization.py.
+# common.parse_json_str; the sync paths are covered in tests/test_json_normalization.py.
+# This adds the async parity that that file lacks (async_media.subjects()).
+
+def test_async_media_subjects_normalizes_json_strings():
+    import asyncio
+
+    class _AResp:
+        def json(self):
+            return {'data': [{'subject': {'app_data': '{"k": 1}'},
+                              'media': {'custom_data': '[1, 2]'}}]}
+
+    class _AConn:
+        async def _get(self, url, **kw):
+            return _AResp()
+
+    m = object.__new__(cogniac.AsyncCogniacMedia)
+    object.__setattr__(m, '_cc', _AConn())
+    object.__setattr__(m, 'media_id', 'm1')
+    data = asyncio.run(m.subjects())
+    assert data[0]['subject']['app_data'] == {'k': 1}
+    assert data[0]['media']['custom_data'] == [1, 2]
 
 
 # ---------------------------------------------------------------------------
@@ -818,6 +863,12 @@ def test_body_arg_reads_file_and_passes_inline_through(tmp_path):
     f.write_text('{"x": 1}')
     assert _body_arg('@' + str(f)) == '{"x": 1}'
     assert _body_arg('{"y": 2}') == '{"y": 2}'
+
+
+def test_body_arg_reads_stdin(monkeypatch):
+    import io as _io
+    monkeypatch.setattr('sys.stdin', _io.StringIO('{"z": 9}'))
+    assert _body_arg('-') == '{"z": 9}'
 
 
 def test_timestamp_accepts_epoch_and_iso():


### PR DESCRIPTION
## Summary

Small follow-ups to #156 (now merged), surfaced by a post-merge audit. All additive — no behavior removed.

- **Async normalization parity (#157):** #156 / #161 normalized `app_data` / `custom_data` JSON strings on the **sync** `CogniacMedia.detections()` / `subjects()` (and `media_associations()`), but `AsyncCogniacMedia.detections()` / `subjects()` were missed. This applies `parse_json_str` there too, so async callers also receive dicts/lists instead of JSON strings. (Repo convention: every sync entity method has a matching async counterpart.)
- **CLI error envelope — type mapping:** `error_exit` emits `{"error": {"type", "status", "message", "hint"}}`. The labels `AuthError` / `LoginError` / `LoginCancelled` now map to `type: "auth"` (so the "no credentials → run `cogniac auth login`" hint actually fires) and `UsageError` to `type: "client"`, instead of falling through to a generic `error` with no hint.
- **README:** add the new entity classes (`CogniacDeployment`, `CogniacDeploymentCapacityClass`, `CogniacWorkflow`, `CogniacBuild`) and refresh the CLI section to the canonical `--<resource>-id` forms plus the new features (`commands` catalog, `--format jsonl`, `--full-media`, `--body @FILE`).

## Tests

- Async `AsyncCogniacMedia.subjects()` normalization (the sync paths are covered by `tests/test_json_normalization.py`; this adds the async parity it lacked).
- The HTTP 429 path in `raise_errors` (raises a retryable `ClientError(429)` and records `Retry-After`), with and without the header.
- `--body -` (stdin) resolution.

Smoke suite passes with no credentials; the read-only live suite passes (pre-existing known failures only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
