### PR TITLE
tenant: support accounting attribute

### DIFF
--- a/cogniac/async_tenant.py
+++ b/cogniac/async_tenant.py
@@ -6,7 +6,7 @@ Copyright (C) 2016 Cogniac Corporation
 
 from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error
 
-mutable_keys = ['name', 'description']
+mutable_keys = ['name', 'description', 'accounting']
 immutable_keys = ['tenant_id', 'created_at', 'created_by', 'modified_at', 'modified_by']
 
 TENANT_ADMIN_ROLE = "tenant_admin"
@@ -68,7 +68,7 @@ class AsyncCogniacTenant(object):
         """
         Update mutable tenant attributes via a single POST call.
 
-        Accepted keys: name, description
+        Accepted keys: name, description, accounting
 
         Example:
             await tenant.set(name="new tenant name")

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -314,6 +314,17 @@ def cmd_tenant(args):
     output(obj_to_dict(cc.tenant), args, 'tenant')
 
 
+def cmd_tenant_accounting_get(args):
+    cc = get_connection(args)
+    output({"accounting": getattr(cc.tenant, "accounting", None)}, args)
+
+
+def cmd_tenant_accounting_set(args):
+    cc = get_connection(args)
+    cc.tenant.accounting = args.value
+    output({"accounting": cc.tenant.accounting}, args)
+
+
 def cmd_tenants(args):
     url_prefix = os.environ.get('COG_URL_PREFIX') or stored_url_prefix() or DEFAULT_COG_URL_PREFIX
     try:
@@ -2390,6 +2401,12 @@ def build_parser():
     tenant_parser.set_defaults(func=cmd_tenant)
     _add_verb(tenant_sub, 'get', cmd_tenant, help='Show the current tenant')
     _add_verb(tenant_sub, 'list', cmd_tenants, help='List tenants you are authorized for')
+
+    ten_acct_parser = tenant_sub.add_parser('accounting')
+    ten_acct_sub = ten_acct_parser.add_subparsers(dest='tenant_accounting_command')
+    _add_verb(ten_acct_sub, 'get', cmd_tenant_accounting_get, hidden=True)
+    _add_verb(ten_acct_sub, 'set', cmd_tenant_accounting_set,
+              [(('value',), {'metavar': 'VALUE'})], hidden=True)
 
     # Historical plural: bare `cogniac tenants` lists all authorized tenants —
     # distinct from singular `cogniac tenant` (current tenant). Registered as its

--- a/cogniac/tenant.py
+++ b/cogniac/tenant.py
@@ -13,6 +13,9 @@ TENANT_USER_ROLE = "tenant_user"
 TENANT_VIEWER_ROLE = "tenant_viewer"
 TENANT_BILLING_ROLE = "tenant_billing"
 
+# server-managed fields that may be set even when absent from the loaded record
+mutable_keys = ('accounting',)
+
 
 ##
 #   CogniacTenant
@@ -38,7 +41,7 @@ class CogniacTenant(object):
         return self.__str__()
 
     def __setattr__(self, name, value):
-        if name not in self._tenant_keys:
+        if name not in self._tenant_keys and name not in mutable_keys:
             super(CogniacTenant, self).__setattr__(name, value)
             return
         data = {name: value}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cogniac"
-version = "3.1.1"
+version = "3.1.2"
 description = "Python SDK for Cogniac Public API"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Adds the `accounting` tenant attribute to the SDK (sync `tenant.accounting = ...`, async `await tenant.set(accounting=...)`) and CLI (`cogniac tenant accounting get|set`). Bump to 3.1.2.