### PR TITLE
edgeflows status: add --start/--end time-range flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,9 @@ cogniac media search            # search: --md5, --filename, --external-media-id
 cogniac edgeflows list          # list all edgeflows
 cogniac edgeflows get <id>      # get specific edgeflow
 cogniac edgeflows status <id>   # status events: --subsystem, --start, --end, --limit
+                                # --start/--end filter on the cloud-receipt timestamp (cc_timestamp),
+                                # not device time (clocks can diverge on a skewed/backfilling EdgeFlow);
+                                # --sort is not exposed (backend defaults to cloudcore_timestamp)
 cogniac cameras list            # list all cameras
 cogniac cameras get <id>        # get specific camera
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ cogniac media download <id>     # download media file to <id>.<ext>; use -o for 
 cogniac media search            # search: --md5, --filename, --external-media-id, --domain-unit, --limit
 cogniac edgeflows list          # list all edgeflows
 cogniac edgeflows get <id>      # get specific edgeflow
-cogniac edgeflows status <id>   # status events: --subsystem, --limit
+cogniac edgeflows status <id>   # status events: --subsystem, --start, --end, --limit
 cogniac cameras list            # list all cameras
 cogniac cameras get <id>        # get specific camera
 ```

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -588,6 +588,8 @@ def cmd_edgeflows_status(args):
         edgeflow = cc.get_edgeflow(args.edgeflow_id)
         events = edgeflow.status(
             subsystem_name=args.subsystem,
+            start=args.start,
+            end=args.end,
             limit=args.limit,
         )
         output([e for e in events], args)
@@ -2985,6 +2987,10 @@ def build_parser():
     _add_verb(ef_sub, 'status', cmd_edgeflows_status,
               [_id('edgeflow_id', 'EdgeFlow ID (gateway_id)'),
                (('--subsystem',), {'help': 'Filter by subsystem'}),
+               (('--start',), {'type': _timestamp, 'metavar': 'EPOCH_OR_ISO8601',
+                               'help': 'Filter status timestamp > start (epoch seconds or ISO 8601)'}),
+               (('--end',), {'type': _timestamp, 'metavar': 'EPOCH_OR_ISO8601',
+                             'help': 'Filter status timestamp < end (epoch seconds or ISO 8601)'}),
                (('--limit',), {'type': int, 'default': 10,
                                'help': 'Max status events (default: 10; pass a larger --limit '
                                        'to widen). Bounds the walk over device history.'})],

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -2988,9 +2988,13 @@ def build_parser():
               [_id('edgeflow_id', 'EdgeFlow ID (gateway_id)'),
                (('--subsystem',), {'help': 'Filter by subsystem'}),
                (('--start',), {'type': _timestamp, 'metavar': 'EPOCH_OR_ISO8601',
-                               'help': 'Filter status timestamp > start (epoch seconds or ISO 8601)'}),
+                               'help': 'Filter by cloudcore-receipt time (cc_timestamp) > start '
+                                       '(epoch seconds or ISO 8601). NOTE: this is the cloud-receipt '
+                                       'clock, not device time, which can differ on a skewed/backfilling EdgeFlow'}),
                (('--end',), {'type': _timestamp, 'metavar': 'EPOCH_OR_ISO8601',
-                             'help': 'Filter status timestamp < end (epoch seconds or ISO 8601)'}),
+                             'help': 'Filter by cloudcore-receipt time (cc_timestamp) < end '
+                                     '(epoch seconds or ISO 8601). NOTE: this is the cloud-receipt '
+                                     'clock, not device time, which can differ on a skewed/backfilling EdgeFlow'}),
                (('--limit',), {'type': int, 'default': 10,
                                'help': 'Max status events (default: 10; pass a larger --limit '
                                        'to widen). Bounds the walk over device history.'})],

--- a/tests/test_coverage_smoke.py
+++ b/tests/test_coverage_smoke.py
@@ -20,6 +20,7 @@ import re
 import pytest
 
 import cogniac
+import cogniac.cli as cli
 from cogniac.cli import (build_parser, resource_aliases, _SYNONYM_GROUPS, _resolve_positional_ids,
                          error_exit, output, _command_catalog, _timestamp, _body_arg)
 from cogniac.common import server_error, raise_errors, ClientError, ServerError
@@ -825,6 +826,41 @@ def test_subject_media_default_limit_is_100():
 
 def test_edgeflow_status_default_limit_is_10():
     assert _parse(['edgeflow', 'status', 'E1']).limit == 10
+
+
+def test_edgeflow_status_accepts_start_end_time_range():
+    # --start/--end use the _timestamp type: epoch or ISO 8601 -> float epoch seconds
+    ns = _parse(['edgeflow', 'status', 'E1',
+                 '--start', '1700000000', '--end', '2026-01-02T03:04:05Z'])
+    assert ns.start == 1700000000.0
+    assert isinstance(ns.end, float)
+    # start/end default to None (omitted) when not passed
+    bare = _parse(['edgeflow', 'status', 'E1'])
+    assert bare.start is None and bare.end is None
+
+
+def test_edgeflow_status_handler_forwards_start_end(monkeypatch):
+    # the handler must pass start/end straight through to CogniacEdgeFlow.status()
+    captured = {}
+
+    class _FakeEdgeflow:
+        def status(self, **kwargs):
+            captured.update(kwargs)
+            return iter([])
+
+    class _FakeConn:
+        def get_edgeflow(self, _id):
+            return _FakeEdgeflow()
+
+    monkeypatch.setattr(cli, 'get_connection', lambda args: _FakeConn())
+    ns = _parse(['edgeflow', 'status', 'E1',
+                 '--start', '1700000000', '--end', '1700003600',
+                 '--subsystem', 'inference'])
+    ns.func(ns)
+    assert captured['start'] == 1700000000.0
+    assert captured['end'] == 1700003600.0
+    assert captured['subsystem_name'] == 'inference'
+    assert captured['limit'] == 10
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #168

## Summary

`cogniac edgeflows status <gateway_id>` previously exposed only `--subsystem` and `--limit`, so any windowed analysis (e.g. throughput over the last 6 hours) required pulling a large `--limit` and filtering client-side. The SDK method `CogniacEdgeFlow.status()` already accepts `start=`/`end=`; this PR wires them through to the CLI.

## Changes

- Add `--start` / `--end` optional flags to the `edgeflows status` subparser and pass them through to `CogniacEdgeFlow.status(start=, end=)`. `--subsystem` and `--limit` continue to work alongside them.
- Update the help text and the `edgeflows status` flag listing in `CLAUDE.md`.
- Add smoke tests covering flag parsing and that the handler forwards `start`/`end` correctly.

## Accepted formats

Both flags use the repo's existing `_timestamp` arg type, so each accepts either:

- **epoch seconds** — e.g. `--start 1700000000`
- **ISO 8601 datetime** — e.g. `--end 2026-01-02T03:04:05Z`

They are converted to float epoch seconds (what `status()` expects). `--start` and `--end` may be given alone or together. No new dependency added (stdlib `datetime.fromisoformat` via the pre-existing helper).

## Verification

- `uv run pytest tests/test_coverage_smoke.py` — 254 passed.
- `cogniac edgeflows status --help` shows both new flags with `EPOCH_OR_ISO8601` metavar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)