### PR TITLE
Fix cogstats aggregating zero for per-model detection subsystems

### DIFF
--- a/cogniac/async_edgeflow.py
+++ b/cogniac/async_edgeflow.py
@@ -227,17 +227,29 @@ class AsyncCogniacEdgeFlow(object):
         start = start - (start % REPORTING_PERIOD_SECONDS)
         end = end - (end % REPORTING_PERIOD_SECONDS)
 
+        # Detection telemetry is reported as one subsystem per deployed
+        # model, named ``model_detections_<model_instance_id>`` (this is how
+        # all CloudFlows report). The ``status`` subsystem filter is exact
+        # match only -- it does not support wildcards/prefixes -- so we pull
+        # all subsystems for the window and aggregate over every event whose
+        # subsystem name begins with ``model_detections_``.
+        MODEL_DETECTIONS_PREFIX = 'model_detections_'
+
         aggregated_stats = {'total': {}, 'app': {}}
         total_model_detections = 0
         total_aggregated_media_pixels = 0
         total_aggregated_gpu_pixels = 0
 
-        async for event in self.status(subsystem_name='model_detections*',
-                                       start=start,
+        async for event in self.status(start=start,
                                        end=end,
                                        sort='edgeflow_timestamp'):
-            app_id = event['subsystem'].split('_')[2]
+            subsystem = event.get('subsystem', '')
+            if not subsystem.startswith(MODEL_DETECTIONS_PREFIX):
+                continue
+            app_id = subsystem[len(MODEL_DETECTIONS_PREFIX):]
             event_status = event['status'].get(app_id)
+            if not event_status:
+                continue
             model_detections = event_status.get('model_detections', 0)
             media_pixels = event_status.get('aggregated_media_pixels', 0)
             gpu_pixels = event_status.get('aggregated_gpu_pixels', 0)

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -410,8 +410,15 @@ class CogniacEdgeFlow(object):
             start = end - 300
         start = start - (start % REPORTING_PERIOD_SECONDS)
         end = end - (end % REPORTING_PERIOD_SECONDS)
-        events = self.status(subsystem_name='model_detections*',
-                             start=start,
+
+        # Detection telemetry is reported as one subsystem per deployed
+        # model, named ``model_detections_<model_instance_id>`` (this is how
+        # all CloudFlows report). The ``status`` subsystem filter is exact
+        # match only -- it does not support wildcards/prefixes -- so we pull
+        # all subsystems for the window and aggregate over every event whose
+        # subsystem name begins with ``model_detections_``.
+        MODEL_DETECTIONS_PREFIX = 'model_detections_'
+        events = self.status(start=start,
                              end=end,
                              sort='edgeflow_timestamp')
 
@@ -420,8 +427,13 @@ class CogniacEdgeFlow(object):
         total_aggregated_media_pixels = 0
         total_aggregated_gpu_pixels = 0
         for event in events:
-            app_id = event['subsystem'].split('_')[2]
+            subsystem = event.get('subsystem', '')
+            if not subsystem.startswith(MODEL_DETECTIONS_PREFIX):
+                continue
+            app_id = subsystem[len(MODEL_DETECTIONS_PREFIX):]
             event_status = event['status'].get(app_id)
+            if not event_status:
+                continue
             model_detections = event_status.get('model_detections', 0)
             media_pixels = event_status.get('aggregated_media_pixels', 0)
             gpu_pixels = event_status.get('aggregated_gpu_pixels', 0)

--- a/tests/test_async_edgeflows.py
+++ b/tests/test_async_edgeflows.py
@@ -53,3 +53,57 @@ class TestAsyncEdgeFlowRead:
             ef = edgeflows[0]
             with pytest.raises(AttributeError, match="set"):
                 ef.name = "should-not-work"
+
+
+# ---------------------------------------------------------------------------
+# get_aggregated_stats: async parity for the per-model `model_detections_<id>`
+# subsystem aggregation fix (no creds). Mirrors the sync regression in
+# tests/test_edgeflows.py. Model-instance ids are placeholders.
+# ---------------------------------------------------------------------------
+
+
+def _async_edgeflow_with_status(events):
+    # bypass __init__ / __setattr__ guard
+    ef = object.__new__(cogniac.AsyncCogniacEdgeFlow)
+    object.__setattr__(ef, '_edgeflow_keys', [])
+    object.__setattr__(ef, 'gateway_id', 'gw-placeholder')
+
+    async def fake_status(*args, **kwargs):
+        msg = 'get_aggregated_stats must not use an exact-match subsystem filter'
+        assert not kwargs.get('subsystem_name'), msg
+        for ev in events:
+            yield ev
+
+    object.__setattr__(ef, 'status', fake_status)
+    return ef
+
+
+def _model_event(model_id, detections, media_pixels, gpu_pixels):
+    return {
+        'subsystem': 'model_detections_%s' % model_id,
+        'status': {
+            model_id: {
+                'model_detections': detections,
+                'aggregated_media_pixels': media_pixels,
+                'aggregated_gpu_pixels': gpu_pixels,
+            }
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_aggregated_stats_sums_per_model_subsystems():
+    events = [
+        _model_event('m0001', detections=5, media_pixels=1000, gpu_pixels=2000),
+        _model_event('m0002', detections=3, media_pixels=500, gpu_pixels=1500),
+        _model_event('m0001', detections=2, media_pixels=100, gpu_pixels=400),
+        {'subsystem': 'ifconfig', 'status': {'wan0': {'ip': '10.0.0.1'}}},
+    ]
+    ef = _async_edgeflow_with_status(events)
+    stats = await ef.get_aggregated_stats(start=1000.0, end=1300.0)
+
+    assert stats['total']['model_detections'] == 10
+    assert stats['total']['aggregated_media_pixels'] == 1600
+    assert stats['total']['aggregated_gpu_pixels'] == 3900
+    assert set(stats['app']) == {'m0001', 'm0002'}
+    assert stats['app']['m0001']['model_detections'] == 7

--- a/tests/test_edgeflows.py
+++ b/tests/test_edgeflows.py
@@ -25,3 +25,111 @@ class TestEdgeFlowRead:
         ef = edgeflows[0]
         fetched = cogniac.CogniacEdgeFlow.get(cc, ef.gateway_id)
         assert fetched.gateway_id == ef.gateway_id
+
+
+# ---------------------------------------------------------------------------
+# get_aggregated_stats: per-model `model_detections_<id>` subsystem aggregation
+# (no creds). Regression for the bug where the code passed the literal
+# subsystem filter 'model_detections*' to status() -- an exact-match filter
+# that matches nothing, so every device reporting per-model subsystems
+# (all CloudFlows) aggregated to zero. The fix pulls all subsystems for the
+# window and sums every event whose subsystem name starts with
+# 'model_detections_'. Model-instance ids are placeholders.
+# ---------------------------------------------------------------------------
+
+
+def _edgeflow_with_status(events):
+    """A CogniacEdgeFlow whose status() yields the given synthetic events.
+
+    Bypasses __init__ (which would try to set a url_prefix / open a session).
+    """
+    # bypass CogniacEdgeFlow.__init__ / __setattr__ (which auto-POSTs)
+    ef = object.__new__(cogniac.CogniacEdgeFlow)
+    object.__setattr__(ef, '_edgeflow_keys', [])
+    object.__setattr__(ef, 'gateway_id', 'gw-placeholder')
+
+    def fake_status(*args, **kwargs):
+        # The fix must not pass an exact-match subsystem filter (that is the
+        # bug); it should pull all subsystems and filter client-side.
+        msg = 'get_aggregated_stats must not use an exact-match subsystem filter'
+        assert not kwargs.get('subsystem_name'), msg
+        for ev in events:
+            yield ev
+
+    object.__setattr__(ef, 'status', fake_status)
+    return ef
+
+
+def _model_event(model_id, detections, media_pixels, gpu_pixels):
+    """A status event as reported per deployed model.
+
+    The subsystem is 'model_detections_<model_id>' and the status dict is
+    keyed by the same <model_id>.
+    """
+    return {
+        'subsystem': 'model_detections_%s' % model_id,
+        'status': {
+            model_id: {
+                'model_detections': detections,
+                'aggregated_media_pixels': media_pixels,
+                'aggregated_gpu_pixels': gpu_pixels,
+            }
+        },
+    }
+
+
+def test_aggregated_stats_sums_per_model_subsystems():
+    events = [
+        _model_event('m0001', detections=5, media_pixels=1000, gpu_pixels=2000),
+        _model_event('m0002', detections=3, media_pixels=500, gpu_pixels=1500),
+        # second window for the first model -> accumulates into the same app
+        _model_event('m0001', detections=2, media_pixels=100, gpu_pixels=400),
+    ]
+    ef = _edgeflow_with_status(events)
+    stats = ef.get_aggregated_stats(start=1000.0, end=1300.0)
+
+    assert stats['total']['model_detections'] == 10
+    assert stats['total']['aggregated_media_pixels'] == 1600
+    assert stats['total']['aggregated_gpu_pixels'] == 3900
+
+    # per-model rollup, keyed by model-instance id
+    assert set(stats['app']) == {'m0001', 'm0002'}
+    assert stats['app']['m0001'] == {
+        'model_detections': 7,
+        'aggregated_media_pixels': 1100,
+        'aggregated_gpu_pixels': 2400,
+    }
+    assert stats['app']['m0002'] == {
+        'model_detections': 3,
+        'aggregated_media_pixels': 500,
+        'aggregated_gpu_pixels': 1500,
+    }
+
+
+def test_aggregated_stats_ignores_unrelated_subsystems():
+    # Pulling all subsystems means unrelated ones must be skipped, not summed.
+    events = [
+        {'subsystem': 'ifconfig', 'status': {'wan0': {'ip': '10.0.0.1'}}},
+        _model_event('m0001', detections=4, media_pixels=800, gpu_pixels=1600),
+        {'subsystem': 'ping', 'status': {'ping_id': 'x'}},
+    ]
+    ef = _edgeflow_with_status(events)
+    stats = ef.get_aggregated_stats(start=1000.0, end=1300.0)
+
+    assert stats['total']['model_detections'] == 4
+    assert stats['total']['aggregated_media_pixels'] == 800
+    assert stats['total']['aggregated_gpu_pixels'] == 1600
+    assert set(stats['app']) == {'m0001'}
+
+
+def test_aggregated_stats_handles_model_id_with_underscores():
+    # Stripping the 'model_detections_' prefix (rather than split('_')[2])
+    # keeps a model id that itself contains underscores intact.
+    mid = 'tenant_abc_42'
+    events = [_model_event(mid, detections=1, media_pixels=10, gpu_pixels=20)]
+    ef = _edgeflow_with_status(events)
+    stats = ef.get_aggregated_stats(start=1000.0, end=1300.0)
+
+    assert stats['total']['model_detections'] == 1
+    assert set(stats['app']) == {mid}
+    assert stats['app'][mid]['aggregated_gpu_pixels'] == 20


### PR DESCRIPTION
Closes #167

## Root cause

`CogniacEdgeFlow.get_aggregated_stats()` (used by `cogstats`) queried:

```python
events = self.status(subsystem_name='model_detections*', start=..., end=..., sort='edgeflow_timestamp')
```

The `status` subsystem filter is **exact-match** — the trailing `*` is not a wildcard. Real detection subsystems are named `model_detections_<model_instance_id>` (one per deployed model, which is how all CloudFlows report telemetry), so `'model_detections*'` matched nothing and the aggregation loop iterated over zero events. `cogstats` therefore reported **0 detections / 0 pixels** for actively-processing devices.

## Fix

Self-contained client-side approach (no backend change):

- Pull all status events for the window (drop the broken exact-match filter) and aggregate over every event whose subsystem name starts with `model_detections_`.
- Derive the per-model id by stripping the `model_detections_` prefix instead of `split('_')[2]`, so model ids containing underscores stay intact.
- Skip unrelated subsystems and events with no matching status payload.
- Return shape and keys (`total`, `app`, `start_timestamp`, `end_timestamp`) are unchanged, so `cogstats` output is identical.

Applied to both the sync (`cogniac/edgeflow.py`) and async (`cogniac/async_edgeflow.py`) paths to preserve sync/async symmetry.

## Tests

Added no-creds regression tests (synthetic per-model `model_detections_<id>` events with placeholder ids):

- `tests/test_edgeflows.py` — asserts non-zero aggregation, per-model rollup, that unrelated subsystems are ignored, and that ids with underscores are handled; also asserts `get_aggregated_stats` no longer passes an exact-match subsystem filter.
- `tests/test_async_edgeflows.py` — async parity.

Full suite: `268 passed, 110 skipped` (live tests skipped — no creds), including `test_parity.py` (sync/async symmetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)