### PR TITLE
edgeflows status --list-subsystems: fix last_seen always null

### DIFF
--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -621,7 +621,13 @@ def _emit_subsystem_summary(edgeflow, args):
         subsystem = event.get('subsystem')
         if not subsystem:
             continue
-        ts = event.get('edgeflow_timestamp')
+        # Real status events carry cc_timestamp (cloud-receipt, canonical),
+        # gw_timestamp (device clock) and a `timestamp` alias -- but never an
+        # `edgeflow_timestamp`. Prefer cloud-receipt time, falling back to the
+        # device clock, so last_seen is populated regardless of payload shape.
+        ts = (event.get('cc_timestamp')
+              or event.get('timestamp')
+              or event.get('gw_timestamp'))
         entry = summary.get(subsystem)
         if entry is None:
             summary[subsystem] = {'subsystem': subsystem, 'last_seen': ts, 'count': 1}

--- a/tests/test_edgeflows.py
+++ b/tests/test_edgeflows.py
@@ -69,15 +69,17 @@ def _run_status(monkeypatch, argv, edgeflow):
 
 
 # Placeholder ids only — no customer identifiers.
+# Real status events key the timestamp as cc_timestamp (cloud-receipt), never
+# edgeflow_timestamp; the fixtures mirror that so last_seen is exercised.
 _SYNTHETIC_EVENTS = [
-    {"subsystem": "model_detections_aaaa", "edgeflow_timestamp": 100.0},
-    {"subsystem": "model_detections_aaaa", "edgeflow_timestamp": 130.0},
-    {"subsystem": "model_detections_bbbb", "edgeflow_timestamp": 131.0},
-    {"subsystem": "http-input-cccc", "edgeflow_timestamp": 90.0},
-    {"subsystem": "gpus", "edgeflow_timestamp": 50.0},
-    {"subsystem": "cpu", "edgeflow_timestamp": 51.0},
-    {"subsystem": "memory", "edgeflow_timestamp": 52.0},
-    {"subsystem": "model_detections_aaaa", "edgeflow_timestamp": 160.0},
+    {"subsystem": "model_detections_aaaa", "cc_timestamp": 100.0},
+    {"subsystem": "model_detections_aaaa", "cc_timestamp": 130.0},
+    {"subsystem": "model_detections_bbbb", "cc_timestamp": 131.0},
+    {"subsystem": "http-input-cccc", "cc_timestamp": 90.0},
+    {"subsystem": "gpus", "cc_timestamp": 50.0},
+    {"subsystem": "cpu", "cc_timestamp": 51.0},
+    {"subsystem": "memory", "cc_timestamp": 52.0},
+    {"subsystem": "model_detections_aaaa", "cc_timestamp": 160.0},
 ]
 
 
@@ -128,6 +130,16 @@ def test_status_without_flag_lists_events(monkeypatch, capsys):
     assert isinstance(out, list)
     assert len(out) == 2
     assert out[0]["subsystem"] == "model_detections_aaaa"
+
+
+def test_list_subsystems_last_seen_falls_back_to_gw_timestamp(monkeypatch, capsys):
+    # An event without cc_timestamp/timestamp must still populate last_seen
+    # from gw_timestamp, rather than reporting null.
+    events = [{"subsystem": "gpus", "gw_timestamp": 77.0}]
+    ef = _FakeEdgeFlow(events)
+    _run_status(monkeypatch, ["edgeflow", "status", "--edgeflow-id", "g1", "--list-subsystems"], ef)
+    out = json.loads(capsys.readouterr().out)
+    assert out == [{"subsystem": "gpus", "last_seen": 77.0, "count": 1}]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`cogniac edgeflows status <gw> --list-subsystems` (added in #174) returned `"last_seen": null` for **every** subsystem.

Found while validating #174 live against a real CloudFlow: discovery worked (all subsystems surfaced) but every `last_seen` was null.

## Root cause

`_emit_subsystem_summary` read `event.get('edgeflow_timestamp')` — a field real status events **never** carry. Actual events key the timestamp as `cc_timestamp` (cloud-receipt, canonical), `gw_timestamp` (device clock), and a `timestamp` alias. So `ts` was always `None`.

The #174 unit fixtures used the same bogus `edgeflow_timestamp` field, so the tests passed against a shape that doesn't exist in production — the bug was masked.

## Fix

- Read `cc_timestamp` (cloud-receipt time), falling back to `timestamp` then `gw_timestamp`, so `last_seen` is populated regardless of payload shape.
- Corrected the test fixtures to the real `cc_timestamp` field (so the existing `last_seen` assertions are now meaningful — they'd fail against the old code), and added a regression test locking the `gw_timestamp` fallback.

## Verification

- `tests/test_edgeflows.py` 7 passed; smoke suite 254 passed.
- Live against a CloudFlow: `last_seen` now carries real cloud-receipt timestamps for `gpus`, `cpu`, `http-input-*`, `model_detections_*`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)