### PR TITLE
edgeflow status(): guarantee a top-level 'timestamp' on every record (#170)

### DIFF
--- a/cogniac/async_edgeflow.py
+++ b/cogniac/async_edgeflow.py
@@ -170,6 +170,16 @@ class AsyncCogniacEdgeFlow(object):
         reverse (bool)         reverse the sorting order: sort high to low
         limit (int)            yield maximum of limit results
         sort (str)             optional sort field
+
+        Record timestamp schema (each yielded record):
+          gw_timestamp  gateway-side sample clock; always present. This is the
+                        canonical clock for time-series math / differencing
+                        cumulative counters, and is recommended for rate math.
+          cc_timestamp  CloudCore receive clock; always present.
+          timestamp     now guaranteed on every yielded record. The backend
+                        omits it on a minority of records; in that case it is
+                        aliased to gw_timestamp here. An existing timestamp is
+                        never overwritten.
         """
         args = []
         if start is not None:
@@ -201,6 +211,13 @@ class AsyncCogniacEdgeFlow(object):
         while url:
             resp = await get_next(url)
             for data in resp['data']:
+                # Guarantee a top-level 'timestamp' on every record. The
+                # backend omits it on a minority of records (they carry only
+                # gw_timestamp/cc_timestamp); alias to gw_timestamp so callers
+                # can sort/diff on data['timestamp'] uniformly. Never clobber
+                # an existing timestamp.
+                if 'timestamp' not in data and 'gw_timestamp' in data:
+                    data['timestamp'] = data['gw_timestamp']
                 yield data
                 count += 1
                 if limit and count == limit:

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -354,6 +354,16 @@ class CogniacEdgeFlow(object):
                                (seconds since epoch)
         reverse (bool)         reverse the sorting order: sort high to low
         limit (int)            yield maximum of limit results
+
+        Record timestamp schema (each yielded record):
+          gw_timestamp  gateway-side sample clock; always present. This is the
+                        canonical clock for time-series math / differencing
+                        cumulative counters, and is recommended for rate math.
+          cc_timestamp  CloudCore receive clock; always present.
+          timestamp     now guaranteed on every yielded record. The backend
+                        omits it on a minority of records; in that case it is
+                        aliased to gw_timestamp here. An existing timestamp is
+                        never overwritten.
         """
         args = []
         if start is not None:
@@ -385,6 +395,13 @@ class CogniacEdgeFlow(object):
         while url:
             resp = get_next(url)
             for data in resp['data']:
+                # Guarantee a top-level 'timestamp' on every record. The
+                # backend omits it on a minority of records (they carry only
+                # gw_timestamp/cc_timestamp); alias to gw_timestamp so callers
+                # can sort/diff on data['timestamp'] uniformly. Never clobber
+                # an existing timestamp.
+                if 'timestamp' not in data and 'gw_timestamp' in data:
+                    data['timestamp'] = data['gw_timestamp']
                 yield data
                 count += 1
                 if limit and count == limit:

--- a/tests/test_async_edgeflows.py
+++ b/tests/test_async_edgeflows.py
@@ -107,3 +107,79 @@ async def test_async_aggregated_stats_sums_per_model_subsystems():
     assert stats['total']['aggregated_gpu_pixels'] == 3900
     assert set(stats['app']) == {'m0001', 'm0002'}
     assert stats['app']['m0001']['model_detections'] == 7
+
+
+# ---------------------------------------------------------------------------
+# status() must guarantee a top-level 'timestamp' on every yielded record.
+# Async parity for the sync regression in tests/test_edgeflows.py: the backend
+# omits 'timestamp' on a minority of records (they carry only
+# gw_timestamp/cc_timestamp); status() aliases timestamp <- gw_timestamp so
+# callers can sort/diff on record['timestamp'] uniformly, never clobbering an
+# existing timestamp.  (no creds; mocked connection)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncConn:
+    """A connection whose async _get returns a single-page status envelope."""
+
+    def __init__(self, records):
+        self._records = records
+
+    async def _get(self, url, *args, **kwargs):
+        return _FakeResp({'data': self._records, 'paging': {'next': None}})
+
+
+def _async_edgeflow_with_conn(records):
+    ef = object.__new__(cogniac.AsyncCogniacEdgeFlow)
+    object.__setattr__(ef, '_edgeflow_keys', [])
+    object.__setattr__(ef, 'gateway_id', 'gw-placeholder')
+    object.__setattr__(ef, '_cc', _FakeAsyncConn(records))
+    return ef
+
+
+def _mixed_status_records():
+    return [
+        {'subsystem': 'http-input-a0001', 'status': {'n': 1},
+         'cc_timestamp': 100.5, 'gw_timestamp': 100.0, 'timestamp': 100.0},
+        {'subsystem': 'http-input-a0001', 'status': {'n': 2},
+         'cc_timestamp': 101.5, 'gw_timestamp': 101.0},  # no 'timestamp'
+        {'subsystem': 'http-input-a0001', 'status': {'n': 3},
+         'cc_timestamp': 102.5, 'gw_timestamp': 102.0, 'timestamp': 102.0},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_status_guarantees_timestamp_on_every_record():
+    ef = _async_edgeflow_with_conn(_mixed_status_records())
+    records = [r async for r in ef.status()]
+    assert len(records) == 3
+    assert all('timestamp' in r for r in records)
+    records.sort(key=lambda r: r['timestamp'])  # must not raise KeyError
+
+
+@pytest.mark.asyncio
+async def test_async_status_does_not_clobber_existing_timestamp():
+    rec = {'subsystem': 's', 'status': {}, 'cc_timestamp': 9.0,
+           'gw_timestamp': 7.0, 'timestamp': 5.0}
+    ef = _async_edgeflow_with_conn([rec])
+    out = [r async for r in ef.status()]
+    assert out[0]['timestamp'] == 5.0  # original preserved, not 7.0
+
+
+@pytest.mark.asyncio
+async def test_async_status_aliases_missing_timestamp_to_gw_timestamp():
+    rec = {'subsystem': 's', 'status': {}, 'cc_timestamp': 9.0,
+           'gw_timestamp': 7.0}  # no 'timestamp'
+    ef = _async_edgeflow_with_conn([rec])
+    out = [r async for r in ef.status()]
+    assert out[0]['timestamp'] == 7.0  # aliased to gw_timestamp
+    assert out[0]['gw_timestamp'] == 7.0
+    assert out[0]['cc_timestamp'] == 9.0

--- a/tests/test_edgeflows.py
+++ b/tests/test_edgeflows.py
@@ -248,3 +248,81 @@ def test_aggregated_stats_handles_model_id_with_underscores():
     assert stats['total']['model_detections'] == 1
     assert set(stats['app']) == {mid}
     assert stats['app'][mid]['aggregated_gpu_pixels'] == 20
+
+
+# ---------------------------------------------------------------------------
+# status() must guarantee a top-level 'timestamp' on every yielded record.
+# The backend omits 'timestamp' on a minority of records (they carry only
+# gw_timestamp/cc_timestamp); status() aliases timestamp <- gw_timestamp so
+# callers can sort/diff on record['timestamp'] uniformly, never clobbering an
+# existing timestamp.  (no creds; mocked connection)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeConn:
+    """A connection whose _get returns a single-page status envelope."""
+
+    def __init__(self, records):
+        self._records = records
+
+    def _get(self, url, *args, **kwargs):
+        return _FakeResp({'data': self._records, 'paging': {'next': None}})
+
+
+def _edgeflow_with_conn(records):
+    ef = object.__new__(cogniac.CogniacEdgeFlow)
+    object.__setattr__(ef, '_edgeflow_keys', [])
+    object.__setattr__(ef, 'gateway_id', 'gw-placeholder')
+    object.__setattr__(ef, '_cc', _FakeConn(records))
+    return ef
+
+
+def _mixed_status_records():
+    # Mirror the real non-uniformity: some records carry a top-level
+    # 'timestamp', some carry only gw_timestamp/cc_timestamp.
+    return [
+        {'subsystem': 'http-input-a0001', 'status': {'n': 1},
+         'cc_timestamp': 100.5, 'gw_timestamp': 100.0, 'timestamp': 100.0},
+        {'subsystem': 'http-input-a0001', 'status': {'n': 2},
+         'cc_timestamp': 101.5, 'gw_timestamp': 101.0},  # no 'timestamp'
+        {'subsystem': 'http-input-a0001', 'status': {'n': 3},
+         'cc_timestamp': 102.5, 'gw_timestamp': 102.0, 'timestamp': 102.0},
+    ]
+
+
+def test_status_guarantees_timestamp_on_every_record():
+    ef = _edgeflow_with_conn(_mixed_status_records())
+    records = list(ef.status())
+    assert len(records) == 3
+    # every yielded record now has a top-level timestamp -> safe to sort
+    assert all('timestamp' in r for r in records)
+    records.sort(key=lambda r: r['timestamp'])  # must not raise KeyError
+
+
+def test_status_does_not_clobber_existing_timestamp():
+    # A record that already has a distinct 'timestamp' keeps its own value and
+    # is NOT overwritten by gw_timestamp.
+    rec = {'subsystem': 's', 'status': {}, 'cc_timestamp': 9.0,
+           'gw_timestamp': 7.0, 'timestamp': 5.0}
+    ef = _edgeflow_with_conn([rec])
+    out = list(ef.status())
+    assert out[0]['timestamp'] == 5.0  # original preserved, not 7.0
+
+
+def test_status_aliases_missing_timestamp_to_gw_timestamp():
+    rec = {'subsystem': 's', 'status': {}, 'cc_timestamp': 9.0,
+           'gw_timestamp': 7.0}  # no 'timestamp'
+    ef = _edgeflow_with_conn([rec])
+    out = list(ef.status())
+    assert out[0]['timestamp'] == 7.0  # aliased to gw_timestamp
+    # the source clocks are left intact
+    assert out[0]['gw_timestamp'] == 7.0
+    assert out[0]['cc_timestamp'] == 9.0


### PR DESCRIPTION
## Problem

`CogniacEdgeFlow.status()` (sync `cogniac/edgeflow.py`, async `cogniac/async_edgeflow.py`) yields raw backend status records, and these are **not uniform**: a significant fraction of records lack a top-level `timestamp` key, carrying only `gw_timestamp` and `cc_timestamp`. In a reported 7-day window, ~15.6% of samples (105 of 673) were missing `timestamp`.

Any client that sorts or diffs on `record["timestamp"]` -- the obvious thing to do for a time series -- raises `KeyError: 'timestamp'` partway through a result set. The non-uniformity is silent until a minority-schema record shows up, so short probes (`limit=1..10`) appear to work and longer windows fail.

## Fix

Combines options 1 and 2 from the issue:

1. **Guarantee a top-level `timestamp` on every yielded record.** When a record has no `timestamp`, alias it to `gw_timestamp` (the gateway-side sample clock, present on every record). An existing `timestamp` is never overwritten; `gw_timestamp` and `cc_timestamp` are left intact. Applied identically to the sync and async generators (the dict is mutated in place before `yield`, which is safe since the generator already yields fresh dicts from the JSON response).

2. **Document the record timestamp schema** in both `status()` docstrings:
   - `gw_timestamp` -- gateway-side sample clock; always present. Canonical for time-series math / differencing cumulative counters, and **recommended for rate math**.
   - `cc_timestamp` -- CloudCore receive clock; always present.
   - `timestamp` -- now guaranteed on every record (aliased to `gw_timestamp` when the backend omits it).

## Tests

Adds sync and async parity tests that mock the connection to return a paging envelope whose `data` mixes records with and without `timestamp`. They assert that every yielded record has a `timestamp`, that records already carrying one keep their original value (not clobbered by `gw_timestamp`), and that a record missing one gets `gw_timestamp`'s value.

`uv run pytest tests/test_edgeflows.py tests/test_async_edgeflows.py tests/test_parity.py tests/test_coverage_smoke.py` -> 268 passed, 11 skipped (live-creds tests).

## Related

Complements #175, which client-side-works-around this same non-uniformity in `--list-subsystems` (`last_seen` reads `cc_timestamp`/`timestamp`/`gw_timestamp` in turn). This PR fixes the root cause at the SDK boundary so callers no longer need to.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)