### PR TITLE
edgeflow: warn that status() pages the full status history (#159)

### DIFF
--- a/cogniac/async_edgeflow.py
+++ b/cogniac/async_edgeflow.py
@@ -177,6 +177,13 @@ class AsyncCogniacEdgeFlow(object):
         limit (int)            yield maximum of limit results
         sort (str)             optional sort field
 
+        WARNING: this is an async generator over the appliance's full status
+        history, not a live stream. Called without limit= or end= on a
+        long-lived EdgeFlow, draining it (e.g. async-for over ef.status())
+        pages through the entire history and may not terminate in practice.
+        Pass limit= or end= to bound the walk. (The cogniac CLI defaults
+        to --limit 10 for this reason.)
+
         Record timestamp schema (each yielded record):
           gw_timestamp  gateway-side sample clock; always present. This is the
                         canonical clock for time-series math / differencing

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -358,6 +358,13 @@ class CogniacEdgeFlow(object):
         reverse (bool)         reverse the sorting order: sort high to low
         limit (int)            yield maximum of limit results
 
+        WARNING: this is a generator over the appliance's full status
+        history, not a live stream. Called without limit= or end= on a
+        long-lived EdgeFlow, draining it (e.g. list(ef.status())) pages
+        through the entire history and may not terminate in practice.
+        Pass limit= or end= to bound the walk. (The cogniac CLI defaults
+        to --limit 10 for this reason.)
+
         Record timestamp schema (each yielded record):
           gw_timestamp  gateway-side sample clock; always present. This is the
                         canonical clock for time-series math / differencing


### PR DESCRIPTION
## What
Adds a `WARNING` to the `EdgeFlow.status()` docstring (sync `edgeflow.py` and async `async_edgeflow.py`) noting that it is a generator over the appliance's **full status history**, not a live stream — a bare `list(ef.status())` on a long-lived device pages through the entire history and may not terminate in practice. The bounding params (`limit=`, `end=`) already exist; the docstring just never said so.

## Why
`status()` reads as if it returns a small recent snapshot. Without `limit=`/`end=` it walks all history, which surprised a caller and was filed as #159. The CLI already guards this (`edgeflow status` defaults to `--limit 10`); this brings the SDK method's own docs in line so an agent reading the method entry sees the constraint.

## Where / scope
Docstring-only, both sync and async `status()` (kept symmetric per repo convention). **No behavior change** — no new default `limit` is imposed, matching the reviewer's earlier call on this item (warn, don't change the default).

## When / how verified
Both modules parse cleanly and are ASCII-only; the change cannot affect runtime behavior.

Fixes #159