### PR TITLE
Add deployment deploy/deploy-status verbs; warn that setting target does not deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ cogniac media download --media-id <id> -o out.jpg  # download media to file
 cogniac edgeflow list                              # list edge devices
 cogniac edgeflow status --edgeflow-id <id> --list-subsystems   # discover which subsystems a device reports
 cogniac application create --body @app.json        # --body takes inline JSON, @FILE, or - (stdin)
+
+cogniac deployment deploy --deployment-group-id <id> --workflow-id <wf>   # DISPATCH a workflow rollout
+                                                   # (--now bypasses the group schedule; --timeout raises the
+                                                   #  client read timeout — the server blocks until every
+                                                   #  EdgeFlow accepts, default 300s)
+cogniac deployment deploy-status --deployment-group-id <id>               # rollout convergence status
+cogniac deployment target workflow set ...         # records target_workflow_id only — does NOT deploy
 ```
 
 Run `cogniac <noun> --help` to explore the tree interactively, or `cogniac commands` for the full machine-readable catalog. An unknown command suggests the closest match.

--- a/cogniac/async_deployment.py
+++ b/cogniac/async_deployment.py
@@ -5,6 +5,7 @@ Copyright (C) 2024 Cogniac Corporation
 """
 
 from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error
+from .deployment import DEPLOY_DEFAULT_TIMEOUT
 
 
 class AsyncCogniacDeployment(object):
@@ -145,11 +146,77 @@ class AsyncCogniacDeployment(object):
         """
         Set the target_workflow_id on this deployment group.
 
+        This only RECORDS the target — it does NOT dispatch a rollout and
+        leaves current_workflow_id unchanged. Call deploy() to actually
+        deploy the workflow to the group's EdgeFlows.
+
         See POST /1/deploymentGroups/{deployment_group_id}/targetWorkflow.
         """
         resp = await self._cc._post("/1/deploymentGroups/%s/targetWorkflow" % self.deployment_group_id,
                                    json={'target_workflow_id': workflow_id})
         return resp.json()
+
+    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+    async def deploy(self, workflow_id, now=False, timeout=None):
+        """
+        DISPATCH a workflow rollout to every EdgeFlow in this deployment group.
+
+        Unlike set_target_workflow(), which only records the target_workflow_id
+        without deploying anything, this call actually triggers the rollout.
+
+        workflow_id (str)  the workflow to deploy
+        now (bool)         False (default): set next_workflow_id — dispatched
+                           immediately when the group has no scheduled_time,
+                           otherwise picked up by the deployment scheduler.
+                           True: set deploy_now_workflow_id — immediate one-off
+                           dispatch that bypasses the group's schedule.
+        timeout (float)    read timeout in seconds (default DEPLOY_DEFAULT_TIMEOUT,
+                           300). The server blocks until every EdgeFlow in the
+                           group accepts the deployment event, so large groups
+                           need a generous timeout. If the call raises a read
+                           timeout the dispatch may still complete server-side —
+                           check deploy_status() before retrying.
+
+        Returns the updated deployment group JSON (next_workflow_id set on a
+        successful dispatch; the group later converges so current_workflow_id
+        == target_workflow_id and next_workflow_id returns to null).
+
+        See POST /1/deploymentGroups/{deployment_group_id}.
+        """
+        if timeout is None:
+            timeout = DEPLOY_DEFAULT_TIMEOUT
+        key = 'deploy_now_workflow_id' if now else 'next_workflow_id'
+        resp = await self._cc._post("/1/deploymentGroups/%s" % self.deployment_group_id,
+                                   json={key: workflow_id}, timeout=timeout)
+        return resp.json()
+
+    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+    async def deploy_status(self):
+        """
+        Return this deployment group's rollout convergence status.
+
+        Idempotent status check: re-GETs the group and returns a dict with
+        target_workflow_id / current_workflow_id / next_workflow_id /
+        deploy_now_workflow_id plus a boolean 'converged' (True when
+        current_workflow_id == target_workflow_id and no next_workflow_id is
+        pending). Use after deploy() — especially after a client read
+        timeout — to determine whether the dispatch completed server-side.
+
+        See GET /1/deploymentGroups/{deployment_group_id}.
+        """
+        resp = await self._cc._get("/1/deploymentGroups/%s" % self.deployment_group_id)
+        group = resp.json()
+        target = group.get('target_workflow_id')
+        current = group.get('current_workflow_id')
+        next_wf = group.get('next_workflow_id')
+        return {
+            'deployment_group_id': group.get('deployment_group_id', self.deployment_group_id),
+            'target_workflow_id': target,
+            'current_workflow_id': current,
+            'next_workflow_id': next_wf,
+            'deploy_now_workflow_id': group.get('deploy_now_workflow_id'),
+            'converged': current is not None and current == target and next_wf is None,
+        }
 
 
 class AsyncCogniacDeploymentCapacityClass(object):

--- a/cogniac/async_deployment.py
+++ b/cogniac/async_deployment.py
@@ -156,13 +156,20 @@ class AsyncCogniacDeployment(object):
                                    json={'target_workflow_id': workflow_id})
         return resp.json()
 
-    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
     async def deploy(self, workflow_id, now=False, timeout=None):
         """
         DISPATCH a workflow rollout to every EdgeFlow in this deployment group.
 
         Unlike set_target_workflow(), which only records the target_workflow_id
         without deploying anything, this call actually triggers the rollout.
+
+        This call is intentionally NOT retried automatically on server errors:
+        the dispatch is not idempotent, and a 5xx raised after the server began
+        processing could double-dispatch the rollout to the fleet. (The
+        transport still retries 429 rate-limits and credential refresh, which
+        are rejected before processing.) After ANY failure — server error or
+        read timeout — check deploy_status() to determine whether the dispatch
+        completed server-side before retrying.
 
         workflow_id (str)  the workflow to deploy
         now (bool)         False (default): set next_workflow_id — dispatched

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -34,6 +34,7 @@ Representative read commands (run `cogniac <noun> --help` to discover the rest):
     cogniac camera get --network-camera-id ID
     cogniac deployment list
     cogniac deployment get --deployment-group-id ID
+    cogniac deployment deploy-status --deployment-group-id ID
     cogniac workflow get --workflow-id ID
 
 Auth commands:
@@ -45,6 +46,7 @@ Representative write commands:
     cogniac subject create <name> [--description D] [--external-id E]
     cogniac subject associate --subject-uid UID --media-id ID [--consensus C]
     cogniac media upload <filename> [--subject-uid UID] [--external-media-id E] [--domain-unit D] [--meta-tags T ...]
+    cogniac deployment deploy --deployment-group-id ID --workflow-id WF [--now] [--timeout SECONDS]
 
 Global options:
     --format json|table   (default: json)
@@ -62,6 +64,7 @@ import os
 from datetime import datetime
 from importlib.metadata import version as _pkg_version, PackageNotFoundError
 
+import httpx
 from tabulate import tabulate
 
 from .cogniac import CogniacConnection, DEFAULT_COG_URL_PREFIX
@@ -1624,6 +1627,47 @@ def cmd_deployments_target_workflow(args):
     try:
         dg = CogniacDeployment.get(cc, args.deployment_group_id)
         output(dg.set_target_workflow(args.workflow_id), args)
+        # foot-gun guard: this verb only records intent (stdout stays pure JSON)
+        sys.stderr.write(json.dumps({
+            "warning": "target_workflow_id set but NOT deployed; run "
+                       "`cogniac deployment deploy --deployment-group-id %s --workflow-id %s` "
+                       "to dispatch the rollout"
+                       % (args.deployment_group_id, args.workflow_id),
+        }) + "\n")
+    except ClientError as e:
+        error_exit("ClientError", str(e))
+
+
+def cmd_deployments_deploy(args):
+    cc = get_connection(args)
+    from .deployment import CogniacDeployment, DEPLOY_DEFAULT_TIMEOUT
+    timeout = args.timeout if args.timeout is not None else DEPLOY_DEFAULT_TIMEOUT
+    try:
+        dg = CogniacDeployment.get(cc, args.deployment_group_id)
+        output(dg.deploy(args.workflow_id, now=args.now, timeout=timeout), args, 'deployment')
+    except ClientError as e:
+        error_exit("ClientError", str(e))
+    except httpx.TimeoutException:
+        # The dispatch blocks server-side until every EdgeFlow in the group
+        # accepts; on large groups the client read times out even though the
+        # server usually completes the rollout.
+        sys.stderr.write(json.dumps({"error": {
+            "type": "timeout",
+            "message": "deploy dispatch timed out client-side after %gs; the server may "
+                       "still complete the rollout" % timeout,
+            "hint": "check convergence with `cogniac deployment deploy-status "
+                    "--deployment-group-id %s`; if not converged, re-run deploy "
+                    "with a larger --timeout" % args.deployment_group_id,
+        }}) + "\n")
+        sys.exit(1)
+
+
+def cmd_deployments_deploy_status(args):
+    cc = get_connection(args)
+    from .deployment import CogniacDeployment
+    try:
+        dg = CogniacDeployment.get(cc, args.deployment_group_id)
+        output(dg.deploy_status(), args)
     except ClientError as e:
         error_exit("ClientError", str(e))
 
@@ -3209,7 +3253,20 @@ def build_parser():
     _add_verb(dep_target_wf_sub, 'set', cmd_deployments_target_workflow,
               [_id('deployment_group_id', 'Deployment group ID'),
                (('--workflow-id',), {'dest': 'workflow_id', 'required': True, 'help': 'Workflow ID'})],
-              help="Set the group's target workflow")
+              help="Record the group's target workflow WITHOUT deploying it (use `deployment deploy` to dispatch)")
+    # deployment deploy / deploy-status
+    _add_verb(dep_sub, 'deploy', cmd_deployments_deploy,
+              [_id('deployment_group_id', 'Deployment group ID'),
+               (('--workflow-id',), {'dest': 'workflow_id', 'required': True, 'help': 'Workflow ID to deploy'}),
+               (('--now',), {'action': 'store_true',
+                             'help': 'Immediate one-off dispatch (deploy_now_workflow_id), bypassing the group schedule'}),
+               (('--timeout',), {'type': float, 'default': None, 'metavar': 'SECONDS',
+                                 'help': 'Client read timeout for the dispatch; the server blocks until '
+                                         'every EdgeFlow accepts, so large groups need more (default 300)'})],
+              help='DISPATCH a workflow rollout to the group (unlike `target workflow set`, which only records intent)')
+    _add_verb(dep_sub, 'deploy-status', cmd_deployments_deploy_status,
+              [_id('deployment_group_id', 'Deployment group ID')],
+              help='Rollout convergence status: target vs current vs pending next workflow')
     # deployment capacity list/get
     def _reg_dep_capacity(sub, hidden=False):
         _add_verb(sub, 'list', cmd_deployment_capacity_list, help='List deployment capacity classes', hidden=hidden)

--- a/cogniac/deployment.py
+++ b/cogniac/deployment.py
@@ -6,6 +6,11 @@ Copyright (C) 2024 Cogniac Corporation
 
 from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error
 
+# Default read timeout (seconds) for deploy(). The dispatch blocks server-side
+# until every EdgeFlow in the group accepts the deployment event, so large
+# groups need far longer than the connection's default 60s timeout.
+DEPLOY_DEFAULT_TIMEOUT = 300
+
 
 ##
 #  CogniacDeployment
@@ -181,11 +186,83 @@ class CogniacDeployment(object):
         """
         Set the target_workflow_id on this deployment group.
 
+        This only RECORDS the target — it does NOT dispatch a rollout and
+        leaves current_workflow_id unchanged. Call deploy() to actually
+        deploy the workflow to the group's EdgeFlows.
+
         See POST /1/deploymentGroups/{deployment_group_id}/targetWorkflow.
         """
         resp = self._cc._post("/1/deploymentGroups/%s/targetWorkflow" % self.deployment_group_id,
                              json={'target_workflow_id': workflow_id})
         return resp.json()
+
+    ##
+    #  deploy
+    ##
+    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+    def deploy(self, workflow_id, now=False, timeout=None):
+        """
+        DISPATCH a workflow rollout to every EdgeFlow in this deployment group.
+
+        Unlike set_target_workflow(), which only records the target_workflow_id
+        without deploying anything, this call actually triggers the rollout.
+
+        workflow_id (str)  the workflow to deploy
+        now (bool)         False (default): set next_workflow_id — dispatched
+                           immediately when the group has no scheduled_time,
+                           otherwise picked up by the deployment scheduler.
+                           True: set deploy_now_workflow_id — immediate one-off
+                           dispatch that bypasses the group's schedule.
+        timeout (float)    read timeout in seconds (default DEPLOY_DEFAULT_TIMEOUT,
+                           300). The server blocks until every EdgeFlow in the
+                           group accepts the deployment event, so large groups
+                           need a generous timeout. If the call raises a read
+                           timeout the dispatch may still complete server-side —
+                           check deploy_status() before retrying.
+
+        Returns the updated deployment group JSON (next_workflow_id set on a
+        successful dispatch; the group later converges so current_workflow_id
+        == target_workflow_id and next_workflow_id returns to null).
+
+        See POST /1/deploymentGroups/{deployment_group_id}.
+        """
+        if timeout is None:
+            timeout = DEPLOY_DEFAULT_TIMEOUT
+        key = 'deploy_now_workflow_id' if now else 'next_workflow_id'
+        resp = self._cc._post("/1/deploymentGroups/%s" % self.deployment_group_id,
+                             json={key: workflow_id}, timeout=timeout)
+        return resp.json()
+
+    ##
+    #  deploy_status
+    ##
+    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+    def deploy_status(self):
+        """
+        Return this deployment group's rollout convergence status.
+
+        Idempotent status check: re-GETs the group and returns a dict with
+        target_workflow_id / current_workflow_id / next_workflow_id /
+        deploy_now_workflow_id plus a boolean 'converged' (True when
+        current_workflow_id == target_workflow_id and no next_workflow_id is
+        pending). Use after deploy() — especially after a client read
+        timeout — to determine whether the dispatch completed server-side.
+
+        See GET /1/deploymentGroups/{deployment_group_id}.
+        """
+        resp = self._cc._get("/1/deploymentGroups/%s" % self.deployment_group_id)
+        group = resp.json()
+        target = group.get('target_workflow_id')
+        current = group.get('current_workflow_id')
+        next_wf = group.get('next_workflow_id')
+        return {
+            'deployment_group_id': group.get('deployment_group_id', self.deployment_group_id),
+            'target_workflow_id': target,
+            'current_workflow_id': current,
+            'next_workflow_id': next_wf,
+            'deploy_now_workflow_id': group.get('deploy_now_workflow_id'),
+            'converged': current is not None and current == target and next_wf is None,
+        }
 
 
 ##

--- a/cogniac/deployment.py
+++ b/cogniac/deployment.py
@@ -199,13 +199,20 @@ class CogniacDeployment(object):
     ##
     #  deploy
     ##
-    @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
     def deploy(self, workflow_id, now=False, timeout=None):
         """
         DISPATCH a workflow rollout to every EdgeFlow in this deployment group.
 
         Unlike set_target_workflow(), which only records the target_workflow_id
         without deploying anything, this call actually triggers the rollout.
+
+        This call is intentionally NOT retried automatically on server errors:
+        the dispatch is not idempotent, and a 5xx raised after the server began
+        processing could double-dispatch the rollout to the fleet. (The
+        transport still retries 429 rate-limits and credential refresh, which
+        are rejected before processing.) After ANY failure — server error or
+        read timeout — check deploy_status() to determine whether the dispatch
+        completed server-side before retrying.
 
         workflow_id (str)  the workflow to deploy
         now (bool)         False (default): set next_workflow_id — dispatched

--- a/tests/test_coverage_smoke.py
+++ b/tests/test_coverage_smoke.py
@@ -152,7 +152,7 @@ def test_user_instance_methods_exist(method):
 
 _DEPLOYMENT_METHODS = ['get_all', 'get', 'create', 'delete', 'edgeflows',
                        'history', 'prepull_status', 'prepull_start',
-                       'set_target_workflow']
+                       'set_target_workflow', 'deploy', 'deploy_status']
 
 
 @pytest.mark.parametrize("method", _DEPLOYMENT_METHODS)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -25,6 +25,7 @@ import httpx
 import pytest
 
 import cogniac
+from cogniac.common import ServerError
 from cogniac.deployment import DEPLOY_DEFAULT_TIMEOUT
 
 
@@ -94,6 +95,38 @@ def test_deploy_timeout_is_configurable():
     assert timeout == 42
 
 
+class _FailingPostConn(_Conn):
+    """_post always fails with the given exception (after recording the attempt)."""
+    def __init__(self, exc):
+        super().__init__([])
+        self._exc = exc
+
+    def _post(self, url, **kwargs):
+        self.posted.append((url, kwargs.get('json'), kwargs.get('timeout')))
+        raise self._exc
+
+
+def test_deploy_does_not_retry_on_server_error():
+    # the dispatch is NOT idempotent: a 5xx after the server began processing
+    # could double-dispatch the rollout, so deploy() must not carry the
+    # blanket server_error retry — a single POST attempt, then propagate
+    conn = _FailingPostConn(ServerError("ServerError (500): transient"))
+    dg = cogniac.CogniacDeployment(conn, {'deployment_group_id': 'dg-test-1'})
+    with pytest.raises(ServerError):
+        dg.deploy('wf-test-1')
+    assert len(conn.posted) == 1
+
+
+def test_deploy_read_timeout_propagates_without_retry():
+    # a client read timeout likewise propagates after one attempt (the caller
+    # resolves the ambiguity via deploy_status())
+    conn = _FailingPostConn(httpx.ReadTimeout("The read operation timed out"))
+    dg = cogniac.CogniacDeployment(conn, {'deployment_group_id': 'dg-test-1'})
+    with pytest.raises(httpx.ReadTimeout):
+        dg.deploy('wf-test-1')
+    assert len(conn.posted) == 1
+
+
 # ---------------------------------------------------------------------------
 # CogniacDeployment.deploy_status — convergence logic
 # ---------------------------------------------------------------------------
@@ -144,6 +177,32 @@ def test_deploy_status_is_a_get():
     dg.deploy_status()
     assert dg._cc.urls == ["/1/deploymentGroups/dg-test-1"]
     assert dg._cc.posted == []
+
+
+class _FlakyGetConn(_Conn):
+    """_get fails `failures` times with a 5xx, then serves the queued payloads."""
+    def __init__(self, failures, payloads):
+        super().__init__(payloads)
+        self._failures = failures
+        self.get_attempts = 0
+
+    def _get(self, url, **kwargs):
+        self.get_attempts += 1
+        if self.get_attempts <= self._failures:
+            raise ServerError("ServerError (500): transient")
+        return super()._get(url, **kwargs)
+
+
+def test_deploy_status_retries_on_server_error():
+    # deploy_status is an idempotent GET, so it keeps the repo-standard
+    # server_error retry (unlike the non-idempotent deploy())
+    conn = _FlakyGetConn(1, [{'target_workflow_id': 'wf-test-1',
+                              'current_workflow_id': 'wf-test-1',
+                              'next_workflow_id': None}])
+    dg = cogniac.CogniacDeployment(conn, {'deployment_group_id': 'dg-test-1'})
+    status = dg.deploy_status()
+    assert conn.get_attempts == 2
+    assert status['converged'] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,247 @@
+"""
+Deployment deploy / deploy-status coverage (no creds, mocked transport).
+
+Guards the deploy-verb surface added for the "set target does not deploy"
+foot-gun (issue #180) and the long-dispatch read-timeout ambiguity (issue #185):
+
+  - CogniacDeployment.deploy() POSTs next_workflow_id (or deploy_now_workflow_id
+    with now=True) to /1/deploymentGroups/{id} with a generous, configurable
+    read timeout — this DISPATCHES a rollout, unlike set_target_workflow which
+    only records intent.
+  - CogniacDeployment.deploy_status() re-GETs the group and reports convergence
+    (current == target with no pending next) idempotently.
+  - CLI `deployment deploy` / `deployment deploy-status` wire to those methods;
+    a client read timeout on dispatch exits nonzero with a deploy-status hint
+    (the server may still complete) instead of a bare traceback.
+  - CLI `deployment target workflow set` warns on stderr that nothing was
+    deployed; stdout stays pure JSON.
+
+No live API calls are made and no real deployment is ever dispatched.
+"""
+
+import json
+
+import httpx
+import pytest
+
+import cogniac
+from cogniac.deployment import DEPLOY_DEFAULT_TIMEOUT
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _Conn:
+    """Minimal fake connection: each _get/_post returns the next queued payload."""
+    def __init__(self, payloads):
+        self._payloads = list(payloads)
+        self.urls = []
+        self.posted = []          # (url, json_body, timeout)
+
+    def _get(self, url, **kwargs):
+        self.urls.append(url)
+        return _Resp(self._payloads.pop(0))
+
+    def _post(self, url, **kwargs):
+        self.posted.append((url, kwargs.get('json'), kwargs.get('timeout')))
+        return _Resp(self._payloads.pop(0))
+
+
+def _deployment_with(payloads):
+    return cogniac.CogniacDeployment(_Conn(payloads), {'deployment_group_id': 'dg-test-1'})
+
+
+# ---------------------------------------------------------------------------
+# CogniacDeployment.deploy — request body, endpoint, and timeout
+# ---------------------------------------------------------------------------
+
+def test_deploy_posts_next_workflow_id():
+    dg = _deployment_with([{'deployment_group_id': 'dg-test-1', 'next_workflow_id': 'wf-test-1'}])
+    result = dg.deploy('wf-test-1')
+    url, body, timeout = dg._cc.posted[0]
+    assert url == "/1/deploymentGroups/dg-test-1"
+    assert body == {'next_workflow_id': 'wf-test-1'}
+    assert result['next_workflow_id'] == 'wf-test-1'
+
+
+def test_deploy_now_posts_deploy_now_workflow_id():
+    dg = _deployment_with([{'deployment_group_id': 'dg-test-1'}])
+    dg.deploy('wf-test-1', now=True)
+    url, body, timeout = dg._cc.posted[0]
+    assert url == "/1/deploymentGroups/dg-test-1"
+    assert body == {'deploy_now_workflow_id': 'wf-test-1'}
+
+
+def test_deploy_default_timeout_is_generous():
+    # the dispatch blocks server-side until every EdgeFlow accepts, so the
+    # default must be far above the connection's 60s default
+    dg = _deployment_with([{}])
+    dg.deploy('wf-test-1')
+    _, _, timeout = dg._cc.posted[0]
+    assert timeout == DEPLOY_DEFAULT_TIMEOUT
+    assert timeout >= 300
+
+
+def test_deploy_timeout_is_configurable():
+    dg = _deployment_with([{}])
+    dg.deploy('wf-test-1', timeout=42)
+    _, _, timeout = dg._cc.posted[0]
+    assert timeout == 42
+
+
+# ---------------------------------------------------------------------------
+# CogniacDeployment.deploy_status — convergence logic
+# ---------------------------------------------------------------------------
+
+def _status_with(group):
+    group.setdefault('deployment_group_id', 'dg-test-1')
+    return _deployment_with([group]).deploy_status()
+
+
+def test_deploy_status_converged():
+    status = _status_with({'target_workflow_id': 'wf-test-1',
+                           'current_workflow_id': 'wf-test-1',
+                           'next_workflow_id': None})
+    assert status['converged'] is True
+    assert status['deployment_group_id'] == 'dg-test-1'
+    assert status['target_workflow_id'] == 'wf-test-1'
+    assert status['current_workflow_id'] == 'wf-test-1'
+    assert status['next_workflow_id'] is None
+
+
+def test_deploy_status_pending_next_not_converged():
+    # dispatch accepted but rollout still in flight
+    status = _status_with({'target_workflow_id': 'wf-test-2',
+                           'current_workflow_id': 'wf-test-2',
+                           'next_workflow_id': 'wf-test-2'})
+    assert status['converged'] is False
+
+
+def test_deploy_status_target_set_but_not_deployed():
+    # the issue #180 foot-gun state: target recorded, nothing dispatched
+    status = _status_with({'target_workflow_id': 'wf-test-2',
+                           'current_workflow_id': 'wf-test-1',
+                           'next_workflow_id': None})
+    assert status['converged'] is False
+
+
+def test_deploy_status_no_current_workflow_not_converged():
+    status = _status_with({'target_workflow_id': None,
+                           'current_workflow_id': None,
+                           'next_workflow_id': None})
+    assert status['converged'] is False
+
+
+def test_deploy_status_is_a_get():
+    dg = _deployment_with([{'target_workflow_id': 'wf-test-1',
+                            'current_workflow_id': 'wf-test-1',
+                            'next_workflow_id': None}])
+    dg.deploy_status()
+    assert dg._cc.urls == ["/1/deploymentGroups/dg-test-1"]
+    assert dg._cc.posted == []
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring — deployment deploy / deploy-status / target workflow set
+# ---------------------------------------------------------------------------
+
+class _FakeDeployment:
+    """Stands in for the CogniacDeployment the handler fetches; never talks to
+    any API."""
+    def __init__(self, deploy_exc=None):
+        self.calls = []
+        self._deploy_exc = deploy_exc
+
+    def deploy(self, workflow_id, now=False, timeout=None):
+        self.calls.append(('deploy', workflow_id, now, timeout))
+        if self._deploy_exc is not None:
+            raise self._deploy_exc
+        return {'deployment_group_id': 'dg-test-1', 'next_workflow_id': workflow_id}
+
+    def deploy_status(self):
+        self.calls.append(('deploy_status',))
+        return {'deployment_group_id': 'dg-test-1', 'converged': True}
+
+    def set_target_workflow(self, workflow_id):
+        self.calls.append(('set_target_workflow', workflow_id))
+        return {'deployment_group_id': 'dg-test-1', 'target_workflow_id': workflow_id}
+
+
+def _invoke_cli(argv, monkeypatch, fake_dg):
+    from cogniac import cli
+    from cogniac import deployment as deployment_module
+    monkeypatch.setattr(cli, 'get_connection', lambda args=None: object())
+    monkeypatch.setattr(deployment_module.CogniacDeployment, 'get',
+                        classmethod(lambda cls, cc, dg_id: fake_dg))
+    parser = cli.build_parser()
+    args = parser.parse_args(argv)
+    cli._resolve_positional_ids(parser, args)
+    args.func(args)
+
+
+def test_cli_deploy_wires_to_sdk(monkeypatch, capsys):
+    dg = _FakeDeployment()
+    _invoke_cli(['deployment', 'deploy',
+                 '--deployment-group-id', 'dg-test-1',
+                 '--workflow-id', 'wf-test-1'], monkeypatch, dg)
+    assert dg.calls == [('deploy', 'wf-test-1', False, DEPLOY_DEFAULT_TIMEOUT)]
+    out = json.loads(capsys.readouterr().out)
+    assert out['next_workflow_id'] == 'wf-test-1'
+
+
+def test_cli_deploy_now_and_timeout_flags(monkeypatch, capsys):
+    dg = _FakeDeployment()
+    _invoke_cli(['deployment', 'deploy',
+                 '--deployment-group-id', 'dg-test-1',
+                 '--workflow-id', 'wf-test-1',
+                 '--now', '--timeout', '600'], monkeypatch, dg)
+    assert dg.calls == [('deploy', 'wf-test-1', True, 600.0)]
+
+
+def test_cli_deploy_read_timeout_exits_with_status_hint(monkeypatch, capsys):
+    # issue #185: a client read timeout must not surface as a bare traceback —
+    # the dispatch may still complete server-side
+    dg = _FakeDeployment(deploy_exc=httpx.ReadTimeout("The read operation timed out"))
+    with pytest.raises(SystemExit) as exc:
+        _invoke_cli(['deployment', 'deploy',
+                     '--deployment-group-id', 'dg-test-1',
+                     '--workflow-id', 'wf-test-1'], monkeypatch, dg)
+    assert exc.value.code != 0
+    captured = capsys.readouterr()
+    err = json.loads(captured.err)
+    assert err['error']['type'] == 'timeout'
+    assert 'still complete' in err['error']['message']
+    assert 'deploy-status' in err['error']['hint']
+    assert 'dg-test-1' in err['error']['hint']
+
+
+def test_cli_deploy_status_wires_to_sdk(monkeypatch, capsys):
+    dg = _FakeDeployment()
+    _invoke_cli(['deployment', 'deploy-status',
+                 '--deployment-group-id', 'dg-test-1'], monkeypatch, dg)
+    assert dg.calls == [('deploy_status',)]
+    out = json.loads(capsys.readouterr().out)
+    assert out['converged'] is True
+
+
+def test_cli_target_set_warns_not_deployed_on_stderr(monkeypatch, capsys):
+    # issue #180: setting the target must warn that nothing was deployed;
+    # the warning goes to stderr so stdout stays pure JSON
+    dg = _FakeDeployment()
+    _invoke_cli(['deployment', 'target', 'workflow', 'set',
+                 '--deployment-group-id', 'dg-test-1',
+                 '--workflow-id', 'wf-test-1'], monkeypatch, dg)
+    assert dg.calls == [('set_target_workflow', 'wf-test-1')]
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)                      # stdout is pure JSON
+    assert out['target_workflow_id'] == 'wf-test-1'
+    warning = json.loads(captured.err)
+    assert 'NOT deployed' in warning['warning']
+    assert 'cogniac deployment deploy' in warning['warning']
+    assert 'dg-test-1' in warning['warning']
+    assert 'wf-test-1' in warning['warning']


### PR DESCRIPTION
## Summary

`cogniac deployment target workflow set` (SDK `set_target_workflow`) records `target_workflow_id` via `POST /1/deploymentGroups/{id}/targetWorkflow` but **never dispatches a rollout** — and no CLI verb or public SDK method did. During a production revert this looked like a completed deploy while `current_workflow_id` was unchanged on every group. The real deploy mechanism (`POST /1/deploymentGroups/{id}` with `next_workflow_id`, or `deploy_now_workflow_id` for a schedule-bypassing immediate dispatch) was only reachable via the private `_post`, and its long synchronous server-side dispatch could time out client-side with no way to tell success from failure.

## Changes

**SDK** (sync `CogniacDeployment` + async `AsyncCogniacDeployment`):
- `deploy(workflow_id, now=False, timeout=None)` — dispatches a rollout via `POST /1/deploymentGroups/{id}` with `next_workflow_id` (immediate when the group has no `scheduled_time`, otherwise picked up by the scheduler) or `deploy_now_workflow_id` with `now=True`. The server blocks until every EdgeFlow in the group accepts, so the call takes a configurable read timeout with a generous default (`DEPLOY_DEFAULT_TIMEOUT`, 300s) instead of the connection's 60s. Returns the updated group JSON.
- `deploy_status()` — idempotent convergence check: re-GETs the group and returns `target/current/next/deploy_now` workflow ids plus a `converged` boolean (`current == target` and no pending `next`). Resolves the ambiguity when a long dispatch times out client-side but completes server-side.
- `set_target_workflow` docstrings now state they record intent only.

**CLI**:
- `cogniac deployment deploy --deployment-group-id <id> --workflow-id <wf> [--now] [--timeout SECONDS]`
- `cogniac deployment deploy-status --deployment-group-id <id>`
- `deployment target workflow set` now emits a **stderr** warning (stdout stays pure JSON): target set but NOT deployed, with the exact deploy command to run; its help text now says it records the target without deploying.
- A client read timeout during deploy prints a structured stderr error (`type: timeout`) explaining the dispatch may still complete server-side, with a `deploy-status` hint, and exits nonzero instead of a bare traceback.

**Docs**: README CLI section gains the new verbs and the record-only caveat.

## Tests

New `tests/test_deployment.py` (mocked transport, no credentials, no live API calls, nothing dispatched): deploy request body for both modes, endpoint, timeout plumbing and default, `deploy_status` convergence truth table, CLI wiring for deploy/deploy-status, the read-timeout guidance path, and the stderr warning on target set (stdout stays parseable JSON). Smoke-test method lists updated so the sync/async symmetry check covers the new methods.

```
304 passed, 110 skipped (live tests skipped — no credentials)
```

Fixes #180
Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)