### PR TITLE
Add workflow version enumeration: SDK get_all_versions + CLI 'workflow version list'

### DIFF
--- a/cogniac/async_workflow.py
+++ b/cogniac/async_workflow.py
@@ -83,6 +83,11 @@ class AsyncCogniacWorkflow(object):
         AsyncCogniacWorkflow objects, following the DynamoDB last_key cursor
         until the versions are drained.
 
+        The versions endpoint yields summary records (workflow_id, version,
+        name, created_at, created_by, description, edgeflow_model, base_id,
+        tenant_id) WITHOUT app_specs; fetch the full workflow via get()
+        before diffing or summarizing.
+
         base_id (str)    the workflow base id; a full workflow_id of the form
                          <base_id>:<version> is also accepted (the version
                          suffix is ignored)

--- a/cogniac/async_workflow.py
+++ b/cogniac/async_workflow.py
@@ -77,6 +77,47 @@ class AsyncCogniacWorkflow(object):
         return AsyncCogniacWorkflow(connection, resp.json())
 
     @classmethod
+    async def get_all_versions(cls, connection, base_id, reverse=True, limit=None, last_key=None):
+        """
+        Async generator yielding every version of a workflow base as
+        AsyncCogniacWorkflow objects, following the DynamoDB last_key cursor
+        until the versions are drained.
+
+        base_id (str)    the workflow base id; a full workflow_id of the form
+                         <base_id>:<version> is also accepted (the version
+                         suffix is ignored)
+        reverse (bool)   newest first when True (default)
+        limit (int)      yield a maximum of limit versions
+        last_key (str)   resume from a previous last_key cursor
+
+        See GET /1/workflows/{base_id}/versions.
+        """
+        base_id = base_id.split(':', 1)[0]  # tolerate a full <base_id>:<version>
+
+        @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+        async def get_next(last_key):
+            params = {'reverse': reverse}
+            if limit is not None:
+                params['limit'] = limit
+            if last_key is not None:
+                params['last_key'] = last_key
+            resp = await connection._get("/1/workflows/%s/versions" % base_id, params=params)
+            return resp.json()
+
+        count = 0
+        while True:
+            resp = await get_next(last_key)
+            data = resp['data'] if isinstance(resp, dict) and 'data' in resp else resp
+            for record in data or []:
+                yield AsyncCogniacWorkflow(connection, record)
+                count += 1
+                if limit and count == limit:
+                    return
+            last_key = resp.get('last_key') if isinstance(resp, dict) else None
+            if not last_key:
+                return
+
+    @classmethod
     @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
     async def get_version(cls, connection, base_id, version):
         """

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -3262,7 +3262,8 @@ def build_parser():
                (('--limit',), {'type': int, 'default': None, 'help': 'Max records'}),
                (('--reverse',), {'action': argparse.BooleanOptionalAction, 'default': True,
                                  'help': 'With --base-id: newest version first (use --no-reverse for oldest first)'})],
-              help='List the tenant workflows (or, with --base-id, the versions of one workflow base)')
+              help='List the tenant workflows (or, with --base-id, the versions of one workflow base; '
+                   'version records are summaries without app_specs — use "workflow get" for the full record)')
     _add_verb(wf_sub, 'get', cmd_workflows_get,
               [_id('workflow_id', 'Workflow ID')], help='Show one workflow')
     _add_verb(wf_sub, 'create', cmd_workflows_create, _BODY, help='Create a workflow')
@@ -3286,7 +3287,8 @@ def build_parser():
                    (('--limit',), {'type': int, 'default': None, 'help': 'Max records'}),
                    (('--reverse',), {'action': argparse.BooleanOptionalAction, 'default': True,
                                      'help': 'Newest version first (use --no-reverse for oldest first)'})],
-                  help='List all versions of a workflow base', hidden=hidden)
+                  help='List all versions of a workflow base (summary records without app_specs; '
+                       'use "workflow get" for the full record)', hidden=hidden)
         _add_verb(sub, 'new', cmd_workflow_version_new,
                   [_id('workflow_id', 'Base workflow ID')] + _BODY_REQ,
                   help='Create a new workflow version', hidden=hidden)

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -35,6 +35,8 @@ Representative read commands (run `cogniac <noun> --help` to discover the rest):
     cogniac deployment list
     cogniac deployment get --deployment-group-id ID
     cogniac workflow get --workflow-id ID
+    cogniac workflow list [--base-id BASE] [--limit L]
+    cogniac workflow version list --base-id BASE [--limit L]
 
 Auth commands:
     cogniac auth                               # check credentials (env vars or stored login)
@@ -93,6 +95,7 @@ _TABLE_COLUMNS = {
     'media_assoc': ['media_id', 'subject_uid', 'probability', 'consensus', 'updated_at'],
     'deployment': ['deployment_group_id', 'name', 'target_workflow_id', 'current_workflow_id'],
     'workflow':   ['workflow_id', 'name', 'tenant_id', 'created_at', 'created_by'],
+    'workflow_version': ['workflow_id', 'version', 'name', 'created_at', 'created_by'],
     'leaderboard': ['rank', 'model_id', 'F1', 'precision', 'recall', 'TP', 'FP', 'FN', 'model_image_id'],
     'eval_metric': ['evaluation_metric_hash', 'name', 'primary', 'active', 'weighted', 'user_tag'],
 }
@@ -1651,8 +1654,21 @@ def cmd_deployment_capacity_get(args):
 def cmd_workflows_list(args):
     cc = get_connection(args)
     from .workflow import CogniacWorkflow
-    workflows = CogniacWorkflow.get_all(cc)
-    output([obj_to_dict(w) for w in workflows], args, 'workflow')
+    base_id = getattr(args, 'base_id', None)
+    limit = getattr(args, 'limit', None)
+    try:
+        if base_id:
+            versions = CogniacWorkflow.get_all_versions(cc, base_id,
+                                                        reverse=getattr(args, 'reverse', True),
+                                                        limit=limit)
+            output([obj_to_dict(v) for v in versions], args, 'workflow_version')
+        else:
+            workflows = CogniacWorkflow.get_all(cc)
+            if limit:
+                workflows = workflows[:limit]
+            output([obj_to_dict(w) for w in workflows], args, 'workflow')
+    except ClientError as e:
+        error_exit("ClientError", str(e))
 
 
 def cmd_workflows_create(args):
@@ -1690,6 +1706,18 @@ def cmd_workflow_version_new(args):
     try:
         wf = CogniacWorkflow.new_version(cc, args.workflow_id, _json_body(args) or {})
         output(obj_to_dict(wf), args)
+    except ClientError as e:
+        error_exit("ClientError", str(e))
+
+
+def cmd_workflow_version_list(args):
+    cc = get_connection(args)
+    from .workflow import CogniacWorkflow
+    try:
+        versions = CogniacWorkflow.get_all_versions(cc, args.base_id,
+                                                    reverse=getattr(args, 'reverse', True),
+                                                    limit=getattr(args, 'limit', None))
+        output([obj_to_dict(v) for v in versions], args, 'workflow_version')
     except ClientError as e:
         error_exit("ClientError", str(e))
 
@@ -3227,7 +3255,14 @@ def build_parser():
     # ======================================================================
     wf_parser = _add_resource(subparsers, 'workflow', help='Workflows')
     wf_sub = wf_parser.add_subparsers(dest='workflows_command')
-    _add_verb(wf_sub, 'list', cmd_workflows_list, help='List the tenant workflows')
+    _add_verb(wf_sub, 'list', cmd_workflows_list,
+              [(('--base-id',), {'dest': 'base_id', 'default': None,
+                                 'help': 'List the versions of this workflow base instead of the tenant workflows '
+                                         '(a full BASE:version workflow id is accepted; the version suffix is ignored)'}),
+               (('--limit',), {'type': int, 'default': None, 'help': 'Max records'}),
+               (('--reverse',), {'action': argparse.BooleanOptionalAction, 'default': True,
+                                 'help': 'With --base-id: newest version first (use --no-reverse for oldest first)'})],
+              help='List the tenant workflows (or, with --base-id, the versions of one workflow base)')
     _add_verb(wf_sub, 'get', cmd_workflows_get,
               [_id('workflow_id', 'Workflow ID')], help='Show one workflow')
     _add_verb(wf_sub, 'create', cmd_workflows_create, _BODY, help='Create a workflow')
@@ -3245,6 +3280,13 @@ def build_parser():
               help='List valid EdgeFlow deployment targets')
     # workflow version new/get
     def _reg_wf_version(sub, hidden=False):
+        _add_verb(sub, 'list', cmd_workflow_version_list,
+                  [_id('base_id', 'Base workflow ID (a full BASE:version id is accepted; '
+                                  'the version suffix is ignored)'),
+                   (('--limit',), {'type': int, 'default': None, 'help': 'Max records'}),
+                   (('--reverse',), {'action': argparse.BooleanOptionalAction, 'default': True,
+                                     'help': 'Newest version first (use --no-reverse for oldest first)'})],
+                  help='List all versions of a workflow base', hidden=hidden)
         _add_verb(sub, 'new', cmd_workflow_version_new,
                   [_id('workflow_id', 'Base workflow ID')] + _BODY_REQ,
                   help='Create a new workflow version', hidden=hidden)

--- a/cogniac/workflow.py
+++ b/cogniac/workflow.py
@@ -108,6 +108,49 @@ class CogniacWorkflow(object):
         return CogniacWorkflow(connection, resp.json())
 
     ##
+    #  get_all_versions
+    ##
+    @classmethod
+    def get_all_versions(cls, connection, base_id, reverse=True, limit=None, last_key=None):
+        """
+        Yield every version of a workflow base as CogniacWorkflow objects,
+        following the DynamoDB last_key cursor until the versions are drained.
+
+        base_id (str)    the workflow base id; a full workflow_id of the form
+                         <base_id>:<version> is also accepted (the version
+                         suffix is ignored)
+        reverse (bool)   newest first when True (default)
+        limit (int)      yield a maximum of limit versions
+        last_key (str)   resume from a previous last_key cursor
+
+        See GET /1/workflows/{base_id}/versions.
+        """
+        base_id = base_id.split(':', 1)[0]  # tolerate a full <base_id>:<version>
+
+        @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+        def get_next(last_key):
+            params = {'reverse': reverse}
+            if limit is not None:
+                params['limit'] = limit
+            if last_key is not None:
+                params['last_key'] = last_key
+            resp = connection._get("/1/workflows/%s/versions" % base_id, params=params)
+            return resp.json()
+
+        count = 0
+        while True:
+            resp = get_next(last_key)
+            data = resp['data'] if isinstance(resp, dict) and 'data' in resp else resp
+            for record in data or []:
+                yield CogniacWorkflow(connection, record)
+                count += 1
+                if limit and count == limit:
+                    return
+            last_key = resp.get('last_key') if isinstance(resp, dict) else None
+            if not last_key:
+                return
+
+    ##
     #  get_version
     ##
     @classmethod

--- a/cogniac/workflow.py
+++ b/cogniac/workflow.py
@@ -116,6 +116,11 @@ class CogniacWorkflow(object):
         Yield every version of a workflow base as CogniacWorkflow objects,
         following the DynamoDB last_key cursor until the versions are drained.
 
+        The versions endpoint yields summary records (workflow_id, version,
+        name, created_at, created_by, description, edgeflow_model, base_id,
+        tenant_id) WITHOUT app_specs; fetch the full workflow via get()
+        before diffing or summarizing.
+
         base_id (str)    the workflow base id; a full workflow_id of the form
                          <base_id>:<version> is also accepted (the version
                          suffix is ignored)

--- a/tests/test_coverage_live.py
+++ b/tests/test_coverage_live.py
@@ -282,6 +282,20 @@ class TestWorkflowReadCoverage:
         fetched = cogniac.CogniacWorkflow.get(cc, wid)
         assert fetched.workflow_id == wid
 
+    def test_workflow_versions_list(self, cc):
+        # get_all_versions() is a generator that drains the last_key cursor
+        workflows = cc.get_all_workflows()
+        if not workflows:
+            pytest.skip("no workflows on tenant")
+        base_id = getattr(workflows[0], 'base_id', None) or getattr(workflows[0], 'workflow_id', None)
+        if not base_id:
+            pytest.skip("workflow has no base id")
+        versions = list(cogniac.CogniacWorkflow.get_all_versions(cc, base_id, limit=5))
+        assert isinstance(versions, list)
+        for v in versions:
+            assert isinstance(v, cogniac.CogniacWorkflow)
+            assert hasattr(v, 'version')
+
 
 @requires_live
 class TestUserReadCoverage:

--- a/tests/test_coverage_smoke.py
+++ b/tests/test_coverage_smoke.py
@@ -168,7 +168,7 @@ def test_deployment_capacity_methods_exist(method):
 
 
 _WORKFLOW_METHODS = ['get_all', 'get', 'create', 'delete', 'edgeflow_targets',
-                     'new_version', 'get_version']
+                     'new_version', 'get_version', 'get_all_versions']
 
 
 @pytest.mark.parametrize("method", _WORKFLOW_METHODS)
@@ -379,6 +379,12 @@ def test_deployment_history_is_generator(cls):
 @pytest.mark.parametrize("cls", [cogniac.CogniacSubject, cogniac.AsyncCogniacSubject])
 def test_subject_media_associations_is_generator(cls):
     assert _is_gen(cls.media_associations)
+
+
+@pytest.mark.parametrize("cls", [cogniac.CogniacWorkflow, cogniac.AsyncCogniacWorkflow])
+def test_workflow_get_all_versions_is_generator(cls):
+    assert _is_gen(cls.get_all_versions), \
+        "%s.get_all_versions should drain last_key as a generator" % cls.__name__
 
 
 # ---------------------------------------------------------------------------
@@ -715,6 +721,45 @@ def test_feedback_follows_paging_envelope():
         {'data': [3], 'paging': {}},
     ])
     assert list(app.feedback()) == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# CogniacWorkflow.get_all_versions (issue #181): drains the last_key cursor,
+# yields CogniacWorkflow objects, honors the client-side limit, and tolerates
+# a full <base_id>:<version> workflow id.
+# ---------------------------------------------------------------------------
+
+def test_workflow_versions_empty_does_not_crash():
+    conn = _Conn([{'data': [], 'last_key': None}])
+    assert list(cogniac.CogniacWorkflow.get_all_versions(conn, 'B1')) == []
+    assert conn.urls == ['/1/workflows/B1/versions']
+
+
+def test_workflow_versions_drains_last_key():
+    conn = _Conn([
+        {'data': [{'workflow_id': 'B1:1', 'version': 1}], 'last_key': 'k1'},
+        {'data': [{'workflow_id': 'B1:0', 'version': 0}], 'last_key': None},
+    ])
+    got = list(cogniac.CogniacWorkflow.get_all_versions(conn, 'B1'))
+    assert [w.workflow_id for w in got] == ['B1:1', 'B1:0']
+    assert all(isinstance(w, cogniac.CogniacWorkflow) for w in got)
+    assert conn.urls == ['/1/workflows/B1/versions'] * 2
+
+
+def test_workflow_versions_limit_stops_before_cursor():
+    conn = _Conn([{'data': [{'workflow_id': 'B1:%d' % i, 'version': i} for i in range(5)],
+                   'last_key': 'k1'}])
+    got = list(cogniac.CogniacWorkflow.get_all_versions(conn, 'B1', limit=3))
+    assert [w.version for w in got] == [0, 1, 2]
+    # the limit is reached mid-page; the cursor must not be followed
+    assert conn.urls == ['/1/workflows/B1/versions']
+
+
+def test_workflow_versions_accepts_full_workflow_id():
+    # a full BASE:version id is truncated to its base before the request
+    conn = _Conn([{'data': [], 'last_key': None}])
+    assert list(cogniac.CogniacWorkflow.get_all_versions(conn, 'B1:7')) == []
+    assert conn.urls == ['/1/workflows/B1/versions']
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "2026-07-09T07:00:00Z"
+
 [[package]]
 name = "anyio"
 version = "4.13.0"
@@ -26,7 +29,7 @@ wheels = [
 
 [[package]]
 name = "cogniac"
-version = "3.1.1"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Fixes #181 — there was no way to enumerate workflow versions; the only options were `workflow get <BASE:version>` (one id at a time) and `workflow list` (tenant bases only), so discovering versions meant guessing `BASE:N` ids until 404.

The backend already exposes `GET /1/workflows/{base_id}/versions` — a paginated, newest-first summary list (`{"data": [...], "last_key": <cursor>}` with `reverse`/`limit`/`last_key` query params). This PR surfaces it in the SDK and CLI.

## SDK

- `CogniacWorkflow.get_all_versions(connection, base_id, reverse=True, limit=None, last_key=None)` — a generator that drains the `last_key` cursor and yields `CogniacWorkflow` objects, mirroring `CogniacDeployment.history`.
- `AsyncCogniacWorkflow.get_all_versions(...)` — async generator, same signature (sync/async symmetry).
- A full `<base_id>:<version>` id is accepted; the version suffix is stripped, matching the backend's own tolerance on version-scoped reads — handy when all you have is the workflow id off a deployment group.

## CLI

```
cogniac workflow version list --base-id BASE [--limit N] [--reverse|--no-reverse]
cogniac workflow version list BASE                 # deprecated positional mirror
cogniac workflow list --base-id BASE               # --base flag form proposed in the issue
```

JSON output includes every field the list endpoint returns (`workflow_id`, `version`, `name`, `created_at`, `created_by`, ...); `--format table` uses new `workflow_version` columns. The hidden flat `workflow-version list` alias is registered via the shared registrar, and `workflow list` also gains `--limit`.

## Tests

- Smoke: method existence sync+async, generator check, and mocked-transport pagination — empty envelope, `last_key` drain across pages, mid-page `--limit` stop without following the cursor, and `BASE:version` truncation.
- Live (read-only, credential-gated): lists versions of the tenant's first workflow base.

`pytest tests/ -q`: **295 passed, 111 skipped** (skips are the credential-gated live tests). Also verified end-to-end against a live tenant: `workflow list`, `workflow version list --base-id ...`, `workflow list --base-id BASE:5 --limit 3`, and the flat alias all return clean JSON arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)