### PR TITLE
Add client-derived EdgeFlow fleet health: `edgeflows health` CLI + SDK health()/get_all_health()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,9 @@ cogniac edgeflows health        # client-derived fleet health summary: per devic
                                 # recent status record; --stale-minutes (default 15) sets the online
                                 # threshold. Not a true heartbeat: the backend does not populate
                                 # connectivity on the gateway record, and a device uploading backlogged
-                                # status can briefly look online.
+                                # status can briefly look online. online is tri-state: true/false, or
+                                # null when that device's status fetch failed (its record then carries
+                                # an `error` key; one bad device never aborts the sweep).
 cogniac edgeflows metrics names              # list available metric names
 cogniac edgeflows metrics list --metric-name <name>   # time-series for a metric; --edgeflow-id scopes to one device,
                                 #   --start/--end (epoch or ISO 8601, supplied together) bound the window

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,13 @@ cogniac edgeflows status <id>   # status events: --subsystem, --start, --end, --
                                 # --start/--end filter on the cloud-receipt timestamp (cc_timestamp),
                                 # not device time (clocks can diverge on a skewed/backfilling EdgeFlow);
                                 # --sort is not exposed (backend defaults to cloudcore_timestamp)
+cogniac edgeflows health        # client-derived fleet health summary: per device {gateway_id, name,
+                                # deployment_group_id, last_seen, online, current_workflow_id}.
+                                # last_seen = cc_timestamp (cloud-receipt clock) of the device's most
+                                # recent status record; --stale-minutes (default 15) sets the online
+                                # threshold. Not a true heartbeat: the backend does not populate
+                                # connectivity on the gateway record, and a device uploading backlogged
+                                # status can briefly look online.
 cogniac edgeflows metrics names              # list available metric names
 cogniac edgeflows metrics list --metric-name <name>   # time-series for a metric; --edgeflow-id scopes to one device,
                                 #   --start/--end (epoch or ISO 8601, supplied together) bound the window

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ cogniac media get --media-id <id>                  # media metadata
 cogniac media download --media-id <id> -o out.jpg  # download media to file
 cogniac edgeflow list                              # list edge devices
 cogniac edgeflow status --edgeflow-id <id> --list-subsystems   # discover which subsystems a device reports
+cogniac edgeflow health                            # fleet health derived from each device's latest status record
 cogniac application create --body @app.json        # --body takes inline JSON, @FILE, or - (stdin)
 ```
 

--- a/cogniac/async_edgeflow.py
+++ b/cogniac/async_edgeflow.py
@@ -4,9 +4,23 @@ Async CogniacEdgeFlow Object Client
 Copyright (C) 2016 Cogniac Corporation
 """
 
+import asyncio
 import os
 from time import time
 from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error
+from .edgeflow import DEFAULT_HEALTH_STALE_SECONDS, _health_record
+
+
+@retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+async def _latest_status_record(connection, gateway_id):
+    """
+    Return the most recent status record for a gateway, or None if the device
+    has never reported status. One bounded GET (reverse-sorted, limit 1)
+    against GET /1/gateways/{gateway_id}/status — no pagination walk.
+    """
+    resp = await connection._get("/1/gateways/%s/status?reverse=True&limit=1" % gateway_id)
+    data = resp.json().get('data') or []
+    return data[0] if data else None
 
 
 class AsyncCogniacEdgeFlow(object):
@@ -89,6 +103,45 @@ class AsyncCogniacEdgeFlow(object):
         params.setdefault('tenant_id', connection.tenant_id)
         resp = await connection._get("/1/metrics", params=params)
         return resp.json()
+
+    @classmethod
+    async def get_all_health(cls, connection, stale_seconds=DEFAULT_HEALTH_STALE_SECONDS, max_workers=8):
+        """
+        Return a client-derived health summary for every EdgeFlow in the
+        currently authenticated tenant: a list of dicts
+
+            {gateway_id, name, deployment_group_id, last_seen, online,
+             current_workflow_id}
+
+        For each device the most recent status record is fetched (limit 1)
+        and its cloud-receipt timestamp (cc_timestamp) becomes the effective
+        ``last_seen``; ``online`` is True when last_seen is within
+        ``stale_seconds`` of now. Per-device status fetches run concurrently,
+        capped at ``max_workers`` in flight.
+
+        connection (AsyncCogniacConnection):  Authenticated AsyncCogniacConnection object
+        stale_seconds (float):                staleness threshold for online (default 900)
+        max_workers (int):                    concurrent status fetches (default 8)
+
+        NOTE: the backend does not populate connectivity on the gateway
+        record itself, so this is a client-side derivation from status
+        records (cloud-receipt clock), NOT a true device heartbeat. A device
+        uploading a backlog of status records can briefly look "online"; a
+        device with no status records has last_seen None and online False.
+        """
+        resp = await connection._get('/1/tenants/%s/gateways' % connection.tenant_id)
+        gateways = resp.json()['data']
+        if not gateways:
+            return []
+
+        semaphore = asyncio.Semaphore(max_workers)
+
+        async def one(gateway):
+            async with semaphore:
+                record = await _latest_status_record(connection, gateway.get('gateway_id'))
+            return _health_record(gateway, record, stale_seconds)
+
+        return list(await asyncio.gather(*[one(gateway) for gateway in gateways]))
 
     ##
     #  __init__
@@ -298,6 +351,32 @@ class AsyncCogniacEdgeFlow(object):
         aggregated_stats['start_timestamp'] = start
         aggregated_stats['end_timestamp'] = end
         return aggregated_stats
+
+    ##
+    #  health
+    ##
+    async def health(self, stale_seconds=DEFAULT_HEALTH_STALE_SECONDS):
+        """
+        Return this EdgeFlow's client-derived health dict:
+
+            {gateway_id, name, deployment_group_id, last_seen, online,
+             current_workflow_id}
+
+        The device's most recent status record is fetched (limit 1) and its
+        cloud-receipt timestamp (cc_timestamp) becomes the effective
+        ``last_seen``; ``online`` is True when last_seen is within
+        ``stale_seconds`` of now (default 900).
+
+        NOTE: this is a client-side derivation from status records
+        (cloud-receipt clock), NOT a true device heartbeat. A device
+        uploading a backlog of status records can briefly look "online"; a
+        device with no status records has last_seen None and online False.
+        """
+        record = await _latest_status_record(self._cc, self.gateway_id)
+        fields = {k: getattr(self, k, None)
+                  for k in ('gateway_id', 'name', 'deployment_group_id',
+                            'current_workflow_id')}
+        return _health_record(fields, record, stale_seconds)
 
     ##
     #  time_bound_media_upload

--- a/cogniac/async_edgeflow.py
+++ b/cogniac/async_edgeflow.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 from time import time
 from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception, server_error
-from .edgeflow import DEFAULT_HEALTH_STALE_SECONDS, _health_record
+from .edgeflow import DEFAULT_HEALTH_STALE_SECONDS, _health_error_record, _health_record
 
 
 @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
@@ -119,6 +119,12 @@ class AsyncCogniacEdgeFlow(object):
         ``stale_seconds`` of now. Per-device status fetches run concurrently,
         capped at ``max_workers`` in flight.
 
+        ``online`` is tri-state: True (recent status), False (determined
+        offline/stale), or None (could not determine — the device's status
+        fetch failed; the failure message is surfaced in an ``error`` key on
+        that record). A failing device degrades its own record rather than
+        aborting the whole fleet sweep.
+
         connection (AsyncCogniacConnection):  Authenticated AsyncCogniacConnection object
         stale_seconds (float):                staleness threshold for online (default 900)
         max_workers (int):                    concurrent status fetches (default 8)
@@ -137,8 +143,11 @@ class AsyncCogniacEdgeFlow(object):
         semaphore = asyncio.Semaphore(max_workers)
 
         async def one(gateway):
-            async with semaphore:
-                record = await _latest_status_record(connection, gateway.get('gateway_id'))
+            try:
+                async with semaphore:
+                    record = await _latest_status_record(connection, gateway.get('gateway_id'))
+            except Exception as e:
+                return _health_error_record(gateway, e)
             return _health_record(gateway, record, stale_seconds)
 
         return list(await asyncio.gather(*[one(gateway) for gateway in gateways]))

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -91,7 +91,7 @@ _TABLE_COLUMNS = {
     'media':     ['media_id', 'filename', 'media_format', 'image_width', 'image_height', 'status'],
     'edgeflow':  ['gateway_id', 'name', 'model', 'description'],
     'edgeflow_health': ['gateway_id', 'name', 'online', 'last_seen',
-                        'deployment_group_id', 'current_workflow_id'],
+                        'deployment_group_id', 'current_workflow_id', 'error'],
     'camera':    ['network_camera_id', 'camera_name', 'url', 'active'],
     'media_assoc': ['media_id', 'subject_uid', 'probability', 'consensus', 'updated_at'],
     'deployment': ['deployment_group_id', 'name', 'target_workflow_id', 'current_workflow_id'],
@@ -611,7 +611,12 @@ def cmd_edgeflows_health(args):
     most recent status record is fetched and its cloud-receipt timestamp
     (cc_timestamp) becomes the effective last_seen; a device with no status
     record within --stale-minutes counts offline. NOT a true device heartbeat
-    — a device uploading backlogged status can briefly look online."""
+    — a device uploading backlogged status can briefly look online.
+
+    online is tri-state: true (recent status), false (determined offline/
+    stale), or null (could not determine — that device's status fetch failed;
+    the failure is surfaced in an `error` key on its record instead of
+    aborting the whole sweep)."""
     cc = get_connection(args)
     try:
         from .edgeflow import CogniacEdgeFlow
@@ -3101,7 +3106,9 @@ def build_parser():
                                                'client-side derivation, not a true device heartbeat; a device '
                                                'uploading backlogged status can briefly look online.'})],
               help='Client-derived fleet health: per device {gateway_id, name, deployment_group_id, '
-                   'last_seen, online, current_workflow_id}')
+                   'last_seen, online, current_workflow_id}. online is tri-state: true, false, or '
+                   'null when that device\'s status fetch failed (its record then carries an error '
+                   'key instead of aborting the sweep)')
 
     # edgeflow certificate
     def _reg_ef_cert(sub, hidden=False):

--- a/cogniac/cli.py
+++ b/cogniac/cli.py
@@ -30,6 +30,7 @@ Representative read commands (run `cogniac <noun> --help` to discover the rest):
     cogniac edgeflow list
     cogniac edgeflow get --edgeflow-id ID
     cogniac edgeflow status --edgeflow-id ID [--subsystem S] [--limit L]
+    cogniac edgeflow health [--stale-minutes N]
     cogniac camera list
     cogniac camera get --network-camera-id ID
     cogniac deployment list
@@ -89,6 +90,8 @@ _TABLE_COLUMNS = {
     'subject':   ['subject_uid', 'name', 'description'],
     'media':     ['media_id', 'filename', 'media_format', 'image_width', 'image_height', 'status'],
     'edgeflow':  ['gateway_id', 'name', 'model', 'description'],
+    'edgeflow_health': ['gateway_id', 'name', 'online', 'last_seen',
+                        'deployment_group_id', 'current_workflow_id'],
     'camera':    ['network_camera_id', 'camera_name', 'url', 'active'],
     'media_assoc': ['media_id', 'subject_uid', 'probability', 'consensus', 'updated_at'],
     'deployment': ['deployment_group_id', 'name', 'target_workflow_id', 'current_workflow_id'],
@@ -596,6 +599,24 @@ def cmd_edgeflows_status(args):
             limit=args.limit,
         )
         output([e for e in events], args)
+    except ClientError as e:
+        error_exit("ClientError", str(e))
+
+
+def cmd_edgeflows_health(args):
+    """Client-derived fleet health: one record per EdgeFlow in the tenant.
+
+    The backend does not populate last_seen/connection_status on the gateway
+    record (see issue #184), so health is derived client-side: each device's
+    most recent status record is fetched and its cloud-receipt timestamp
+    (cc_timestamp) becomes the effective last_seen; a device with no status
+    record within --stale-minutes counts offline. NOT a true device heartbeat
+    — a device uploading backlogged status can briefly look online."""
+    cc = get_connection(args)
+    try:
+        from .edgeflow import CogniacEdgeFlow
+        result = CogniacEdgeFlow.get_all_health(cc, stale_seconds=args.stale_minutes * 60.0)
+        output(result, args, 'edgeflow_health')
     except ClientError as e:
         error_exit("ClientError", str(e))
 
@@ -3072,6 +3093,15 @@ def build_parser():
                                     'help': 'Max events scanned by --list-subsystems (default: 8000). '
                                             'If the scan hits this cap a notice is written to stderr.'})],
               help='EdgeFlow status events')
+    _add_verb(ef_sub, 'health', cmd_edgeflows_health,
+              [(('--stale-minutes',), {'dest': 'stale_minutes', 'type': float, 'default': 15.0,
+                                       'help': 'Minutes since the most recent status record before a device '
+                                               'counts offline (default: 15). last_seen is the cloud-receipt '
+                                               'timestamp (cc_timestamp) of the latest status record — a '
+                                               'client-side derivation, not a true device heartbeat; a device '
+                                               'uploading backlogged status can briefly look online.'})],
+              help='Client-derived fleet health: per device {gateway_id, name, deployment_group_id, '
+                   'last_seen, online, current_workflow_id}')
 
     # edgeflow certificate
     def _reg_ef_cert(sub, hidden=False):

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -57,6 +57,22 @@ def _health_record(gateway_fields, latest_record, stale_seconds, now=None):
     }
 
 
+def _health_error_record(gateway_fields, exc):
+    """
+    Degraded health record for a device whose status fetch failed.
+
+    ``online`` is None — tri-state "could not determine", as opposed to False
+    "determined offline" — ``last_seen`` is None, and the failure is surfaced
+    in ``error``, so one bad device (e.g. a gateway deleted between the tenant
+    list call and its status GET, or a device whose status GET exhausts its
+    retries) degrades its own record instead of aborting the fleet sweep.
+    """
+    record = _health_record(gateway_fields, None, 0)
+    record['online'] = None
+    record['error'] = str(exc)
+    return record
+
+
 @retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
 def _latest_status_record(connection, gateway_id):
     """
@@ -176,6 +192,12 @@ class CogniacEdgeFlow(object):
         ``stale_seconds`` of now. Per-device status fetches run concurrently
         on up to ``max_workers`` threads.
 
+        ``online`` is tri-state: True (recent status), False (determined
+        offline/stale), or None (could not determine — the device's status
+        fetch failed; the failure message is surfaced in an ``error`` key on
+        that record). A failing device degrades its own record rather than
+        aborting the whole fleet sweep.
+
         connection (CogniacConnection):  Authenticated CogniacConnection object
         stale_seconds (float):           staleness threshold for online (default 900)
         max_workers (int):               concurrent status fetches (default 8)
@@ -186,13 +208,16 @@ class CogniacEdgeFlow(object):
         uploading a backlog of status records can briefly look "online"; a
         device with no status records has last_seen None and online False.
         """
-        resp = connection._get('/1/tenants/%s/gateways' % connection.tenant_id)
+        resp = connection._get('/1/tenants/%s/gateways' % connection.tenant.tenant_id)
         gateways = resp.json()['data']
         if not gateways:
             return []
 
         def one(gateway):
-            record = _latest_status_record(connection, gateway.get('gateway_id'))
+            try:
+                record = _latest_status_record(connection, gateway.get('gateway_id'))
+            except Exception as e:
+                return _health_error_record(gateway, e)
             return _health_record(gateway, record, stale_seconds)
 
         with ThreadPoolExecutor(max_workers=min(max_workers, len(gateways))) as pool:

--- a/cogniac/edgeflow.py
+++ b/cogniac/edgeflow.py
@@ -6,6 +6,7 @@ Copyright (C) 2016 Cogniac Corporation
 
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 from time import time
 import httpx
 from .common import retry, stop_after_attempt, wait_exponential, retry_if_exception
@@ -17,6 +18,55 @@ IP_REGEX = re.compile('^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}(
 
 
 CLOUDFLOW_PREFIX = "cloudflow.cogniac.io"
+
+# default staleness threshold for the client-derived health summary (seconds);
+# a device whose most recent status record is older than this counts offline
+DEFAULT_HEALTH_STALE_SECONDS = 15 * 60
+
+
+def _health_record(gateway_fields, latest_record, stale_seconds, now=None):
+    """
+    Derive a client-side health dict for one gateway from its most recent
+    status record.
+
+    ``last_seen`` is the cloud-receipt timestamp (``cc_timestamp``) of the
+    device's most recent status record, falling back to ``timestamp`` /
+    ``gw_timestamp`` on records that lack it; ``online`` means last_seen is
+    within ``stale_seconds`` of ``now``.
+
+    NOTE: this is a client-side derivation from status records (cloud-receipt
+    clock), NOT a true device heartbeat. A device uploading a backlog of
+    status records can briefly look "online" while the backlog drains. A
+    device with no status records at all has last_seen None and online False.
+    """
+    if now is None:
+        now = time()
+    last_seen = None
+    if latest_record:
+        last_seen = (latest_record.get('cc_timestamp')
+                     or latest_record.get('timestamp')
+                     or latest_record.get('gw_timestamp'))
+    online = last_seen is not None and (now - last_seen) <= stale_seconds
+    return {
+        'gateway_id': gateway_fields.get('gateway_id'),
+        'name': gateway_fields.get('name'),
+        'deployment_group_id': gateway_fields.get('deployment_group_id'),
+        'last_seen': last_seen,
+        'online': online,
+        'current_workflow_id': gateway_fields.get('current_workflow_id'),
+    }
+
+
+@retry(stop=stop_after_attempt(8), wait=wait_exponential(multiplier=0.5), retry=retry_if_exception(server_error))
+def _latest_status_record(connection, gateway_id):
+    """
+    Return the most recent status record for a gateway, or None if the device
+    has never reported status. One bounded GET (reverse-sorted, limit 1)
+    against GET /1/gateways/{gateway_id}/status — no pagination walk.
+    """
+    resp = connection._get("/1/gateways/%s/status?reverse=True&limit=1" % gateway_id)
+    data = resp.json().get('data') or []
+    return data[0] if data else None
 
 
 class CogniacEdgeFlow(object):
@@ -110,6 +160,43 @@ class CogniacEdgeFlow(object):
         params.setdefault('tenant_id', connection.tenant_id)
         resp = connection._get("/1/metrics", params=params)
         return resp.json()
+
+    @classmethod
+    def get_all_health(cls, connection, stale_seconds=DEFAULT_HEALTH_STALE_SECONDS, max_workers=8):
+        """
+        Return a client-derived health summary for every EdgeFlow in the
+        currently authenticated tenant: a list of dicts
+
+            {gateway_id, name, deployment_group_id, last_seen, online,
+             current_workflow_id}
+
+        For each device the most recent status record is fetched (limit 1)
+        and its cloud-receipt timestamp (cc_timestamp) becomes the effective
+        ``last_seen``; ``online`` is True when last_seen is within
+        ``stale_seconds`` of now. Per-device status fetches run concurrently
+        on up to ``max_workers`` threads.
+
+        connection (CogniacConnection):  Authenticated CogniacConnection object
+        stale_seconds (float):           staleness threshold for online (default 900)
+        max_workers (int):               concurrent status fetches (default 8)
+
+        NOTE: the backend does not populate connectivity on the gateway
+        record itself, so this is a client-side derivation from status
+        records (cloud-receipt clock), NOT a true device heartbeat. A device
+        uploading a backlog of status records can briefly look "online"; a
+        device with no status records has last_seen None and online False.
+        """
+        resp = connection._get('/1/tenants/%s/gateways' % connection.tenant_id)
+        gateways = resp.json()['data']
+        if not gateways:
+            return []
+
+        def one(gateway):
+            record = _latest_status_record(connection, gateway.get('gateway_id'))
+            return _health_record(gateway, record, stale_seconds)
+
+        with ThreadPoolExecutor(max_workers=min(max_workers, len(gateways))) as pool:
+            return list(pool.map(one, gateways))
 
     def __init__(self, connection, edgeflow_dict, timeout=60):
         """
@@ -478,6 +565,32 @@ class CogniacEdgeFlow(object):
         aggregated_stats['start_timestamp'] = start
         aggregated_stats['end_timestamp'] = end
         return aggregated_stats
+
+    ##
+    #  health
+    ##
+    def health(self, stale_seconds=DEFAULT_HEALTH_STALE_SECONDS):
+        """
+        Return this EdgeFlow's client-derived health dict:
+
+            {gateway_id, name, deployment_group_id, last_seen, online,
+             current_workflow_id}
+
+        The device's most recent status record is fetched (limit 1) and its
+        cloud-receipt timestamp (cc_timestamp) becomes the effective
+        ``last_seen``; ``online`` is True when last_seen is within
+        ``stale_seconds`` of now (default 900).
+
+        NOTE: this is a client-side derivation from status records
+        (cloud-receipt clock), NOT a true device heartbeat. A device
+        uploading a backlog of status records can briefly look "online"; a
+        device with no status records has last_seen None and online False.
+        """
+        record = _latest_status_record(self._cc, self.gateway_id)
+        fields = {k: getattr(self, k, None)
+                  for k in ('gateway_id', 'name', 'deployment_group_id',
+                            'current_workflow_id')}
+        return _health_record(fields, record, stale_seconds)
 
     ##
     #  delete

--- a/tests/test_async_edgeflows.py
+++ b/tests/test_async_edgeflows.py
@@ -265,7 +265,11 @@ from time import time
 
 class _AsyncHealthConn:
     """Fake async connection serving the tenant gateway list and one status
-    envelope per gateway (latest record only)."""
+    envelope per gateway (latest record only). A per-gateway value that is an
+    Exception is raised from that device's status GET.
+
+    Exposes tenant_id directly: AsyncCogniacConnection has no `tenant`
+    property, and the async get_all/get_all_health use connection.tenant_id."""
 
     def __init__(self, gateways, status_by_gateway):
         self.tenant_id = 'tenant-placeholder'
@@ -280,6 +284,8 @@ class _AsyncHealthConn:
         assert m, "unexpected url %s" % url
         self.status_urls.append(url)
         records = self._status.get(m.group(1), [])
+        if isinstance(records, Exception):
+            raise records
         return _FakeResp({'data': records[:1], 'paging': {'next': None}})
 
 
@@ -326,6 +332,40 @@ async def test_async_get_all_health_online_stale_and_no_records():
 async def test_async_get_all_health_empty_tenant():
     conn = _AsyncHealthConn([], {})
     assert await cogniac.AsyncCogniacEdgeFlow.get_all_health(conn) == []
+
+
+@pytest.mark.asyncio
+async def test_async_get_all_health_one_bad_device_degrades_not_aborts():
+    # Mirrors the sync regression: a 404 ClientError from one device's status
+    # GET (e.g. gateway deleted mid-sweep) degrades only that record — online
+    # None (tri-state "could not determine") with the failure in `error` —
+    # while every other device still reports normally.
+    from cogniac.common import ClientError
+
+    now = time()
+    gateways = [
+        _gw('gw-ok'),
+        _gw('gw-gone', deployment_group_id='dg-0002'),
+        _gw('gw-quiet'),
+    ]
+    status = {
+        'gw-ok': [{'subsystem': 'cpu', 'cc_timestamp': now - 30.0}],
+        'gw-gone': ClientError('gateway not found (404)', status_code=404),
+        'gw-quiet': [],
+    }
+    conn = _AsyncHealthConn(gateways, status)
+    out = await cogniac.AsyncCogniacEdgeFlow.get_all_health(conn, stale_seconds=900)
+
+    assert [r['gateway_id'] for r in out] == ['gw-ok', 'gw-gone', 'gw-quiet']
+
+    degraded = out[1]
+    assert degraded['online'] is None
+    assert degraded['last_seen'] is None
+    assert '404' in degraded['error']
+    assert degraded['deployment_group_id'] == 'dg-0002'
+
+    assert out[0]['online'] is True and 'error' not in out[0]
+    assert out[2]['online'] is False and 'error' not in out[2]
 
 
 @pytest.mark.asyncio

--- a/tests/test_async_edgeflows.py
+++ b/tests/test_async_edgeflows.py
@@ -251,3 +251,97 @@ async def test_async_status_aliases_missing_timestamp_to_gw_timestamp():
     assert out[0]['timestamp'] == 7.0  # aliased to gw_timestamp
     assert out[0]['gw_timestamp'] == 7.0
     assert out[0]['cc_timestamp'] == 9.0
+
+
+# ---------------------------------------------------------------------------
+# health / get_all_health — async parity for the client-derived fleet health
+# summary (#184). Mirrors the sync tests in tests/test_edgeflows.py.
+# (no creds; mocked connection). Placeholder ids only.
+# ---------------------------------------------------------------------------
+
+import re
+from time import time
+
+
+class _AsyncHealthConn:
+    """Fake async connection serving the tenant gateway list and one status
+    envelope per gateway (latest record only)."""
+
+    def __init__(self, gateways, status_by_gateway):
+        self.tenant_id = 'tenant-placeholder'
+        self._gateways = gateways
+        self._status = status_by_gateway
+        self.status_urls = []
+
+    async def _get(self, url, *args, **kwargs):
+        if url == '/1/tenants/tenant-placeholder/gateways':
+            return _FakeResp({'data': self._gateways})
+        m = re.match(r'^/1/gateways/([^/?]+)/status\?(.*)$', url)
+        assert m, "unexpected url %s" % url
+        self.status_urls.append(url)
+        records = self._status.get(m.group(1), [])
+        return _FakeResp({'data': records[:1], 'paging': {'next': None}})
+
+
+def _gw(gateway_id, **extra):
+    d = {'gateway_id': gateway_id, 'name': 'ef-%s' % gateway_id}
+    d.update(extra)
+    return d
+
+
+@pytest.mark.asyncio
+async def test_async_get_all_health_online_stale_and_no_records():
+    now = time()
+    gateways = [
+        _gw('gw-online', deployment_group_id='dg-0001', current_workflow_id='wf-0001'),
+        _gw('gw-stale'),
+        _gw('gw-silent'),
+    ]
+    status = {
+        'gw-online': [{'subsystem': 'cpu', 'cc_timestamp': now - 60.0,
+                       'gw_timestamp': now - 65.0}],
+        'gw-stale': [{'subsystem': 'cpu', 'cc_timestamp': now - 7200.0}],
+        'gw-silent': [],
+    }
+    conn = _AsyncHealthConn(gateways, status)
+    out = await cogniac.AsyncCogniacEdgeFlow.get_all_health(conn, stale_seconds=900)
+
+    assert [r['gateway_id'] for r in out] == ['gw-online', 'gw-stale', 'gw-silent']
+    by_id = {r['gateway_id']: r for r in out}
+    assert by_id['gw-online']['online'] is True
+    # last_seen is the cloud-receipt clock (cc_timestamp), not gw_timestamp
+    assert by_id['gw-online']['last_seen'] == pytest.approx(now - 60.0)
+    assert by_id['gw-online']['deployment_group_id'] == 'dg-0001'
+    assert by_id['gw-online']['current_workflow_id'] == 'wf-0001'
+    assert by_id['gw-stale']['online'] is False
+    assert by_id['gw-stale']['deployment_group_id'] is None
+    assert by_id['gw-silent']['last_seen'] is None
+    assert by_id['gw-silent']['online'] is False
+    # one bounded status GET per device
+    assert len(conn.status_urls) == 3
+    assert all('limit=1' in u and 'reverse=True' in u for u in conn.status_urls)
+
+
+@pytest.mark.asyncio
+async def test_async_get_all_health_empty_tenant():
+    conn = _AsyncHealthConn([], {})
+    assert await cogniac.AsyncCogniacEdgeFlow.get_all_health(conn) == []
+
+
+@pytest.mark.asyncio
+async def test_async_instance_health():
+    now = time()
+    conn = _AsyncHealthConn([], {'gw-placeholder': [{'cc_timestamp': now - 5.0}]})
+    ef = object.__new__(cogniac.AsyncCogniacEdgeFlow)
+    object.__setattr__(ef, '_edgeflow_keys', [])
+    object.__setattr__(ef, 'gateway_id', 'gw-placeholder')
+    object.__setattr__(ef, 'name', 'ef-placeholder')
+    object.__setattr__(ef, '_cc', conn)
+
+    h = await ef.health()
+    assert h['gateway_id'] == 'gw-placeholder'
+    assert h['online'] is True
+    assert h['last_seen'] == pytest.approx(now - 5.0)
+    # fields absent on the gateway record surface as null, not AttributeError
+    assert h['deployment_group_id'] is None
+    assert h['current_workflow_id'] is None

--- a/tests/test_coverage_smoke.py
+++ b/tests/test_coverage_smoke.py
@@ -70,11 +70,13 @@ _MEDIA_METHODS = ['update', 'delete', 'share', 'create_detection', 'detections',
                   'embeddings', 'download']
 _EDGEFLOW_METHODS = ['update', 'delete', 'get_certificate', 'set_certificate',
                      'replace_certificate', 'delete_certificate', 'metrics', 'status',
+                     'health',
                      # device-control events
                      'reboot', 'ping', 'upgrade', 'set_boot_software_version',
                      'factory_reset', 'flush_upload_queue', 'time_bound_media_upload',
                      'trigger_camera_capture']
-_EDGEFLOW_CLASSMETHODS = ['create', 'get', 'get_all', 'metric_names', 'all_metrics']
+_EDGEFLOW_CLASSMETHODS = ['create', 'get', 'get_all', 'metric_names', 'all_metrics',
+                          'get_all_health']
 _TENANT_METHODS = ['get_edgeflow_certificate', 'set_edgeflow_certificate',
                    'delete_edgeflow_certificate', 'delete_meraki_api_key',
                    'invites', 'create_invite', 'delete_invite', 'users']

--- a/tests/test_edgeflows.py
+++ b/tests/test_edgeflows.py
@@ -3,6 +3,8 @@ Baseline tests for CogniacEdgeFlow.
 """
 
 import json
+import re
+from time import time
 
 import pytest
 from tests.conftest import requires_live
@@ -464,3 +466,171 @@ def test_status_aliases_missing_timestamp_to_gw_timestamp():
     # the source clocks are left intact
     assert out[0]['gw_timestamp'] == 7.0
     assert out[0]['cc_timestamp'] == 9.0
+
+
+# ---------------------------------------------------------------------------
+# health / get_all_health — client-derived fleet health summary (#184).
+# The backend does not populate last_seen/connection_status on the gateway
+# record, so health is derived client-side from each device's most recent
+# status record (cc_timestamp, cloud-receipt clock). (no creds; mocked
+# connection). Placeholder ids only — no customer identifiers.
+# ---------------------------------------------------------------------------
+
+
+class _HealthConn:
+    """Fake connection serving the tenant gateway list and one status
+    envelope per gateway (latest record only, as the API returns for
+    reverse=True&limit=1)."""
+
+    def __init__(self, gateways, status_by_gateway):
+        self.tenant_id = 'tenant-placeholder'
+        self._gateways = gateways
+        self._status = status_by_gateway
+        self.status_urls = []
+
+    def _get(self, url, *args, **kwargs):
+        if url == '/1/tenants/tenant-placeholder/gateways':
+            return _FakeResp({'data': self._gateways})
+        m = re.match(r'^/1/gateways/([^/?]+)/status\?(.*)$', url)
+        assert m, "unexpected url %s" % url
+        self.status_urls.append(url)
+        records = self._status.get(m.group(1), [])
+        return _FakeResp({'data': records[:1], 'paging': {'next': None}})
+
+
+def _gw(gateway_id, **extra):
+    d = {'gateway_id': gateway_id, 'name': 'ef-%s' % gateway_id}
+    d.update(extra)
+    return d
+
+
+def test_get_all_health_online_stale_and_no_records():
+    now = time()
+    gateways = [
+        _gw('gw-online', deployment_group_id='dg-0001', current_workflow_id='wf-0001'),
+        _gw('gw-stale'),
+        _gw('gw-silent'),  # zero status records ever
+    ]
+    status = {
+        'gw-online': [{'subsystem': 'cpu', 'cc_timestamp': now - 60.0,
+                       'gw_timestamp': now - 65.0}],
+        'gw-stale': [{'subsystem': 'cpu', 'cc_timestamp': now - 7200.0}],
+        'gw-silent': [],
+    }
+    conn = _HealthConn(gateways, status)
+    out = cogniac.CogniacEdgeFlow.get_all_health(conn, stale_seconds=900)
+
+    # one record per gateway, in the tenant list's order
+    assert [r['gateway_id'] for r in out] == ['gw-online', 'gw-stale', 'gw-silent']
+    by_id = {r['gateway_id']: r for r in out}
+
+    online = by_id['gw-online']
+    assert online['online'] is True
+    # last_seen is the cloud-receipt clock (cc_timestamp), not gw_timestamp
+    assert online['last_seen'] == pytest.approx(now - 60.0)
+    assert online['name'] == 'ef-gw-online'
+    assert online['deployment_group_id'] == 'dg-0001'
+    assert online['current_workflow_id'] == 'wf-0001'
+
+    stale = by_id['gw-stale']
+    assert stale['online'] is False
+    assert stale['last_seen'] == pytest.approx(now - 7200.0)
+    # fields absent on the gateway record surface as null, not KeyError
+    assert stale['deployment_group_id'] is None
+    assert stale['current_workflow_id'] is None
+
+    # a device with zero status records is handled gracefully
+    silent = by_id['gw-silent']
+    assert silent['last_seen'] is None
+    assert silent['online'] is False
+
+    # each device cost exactly one bounded status GET (latest record only)
+    assert len(conn.status_urls) == 3
+    assert all('limit=1' in url and 'reverse=True' in url for url in conn.status_urls)
+
+
+def test_get_all_health_stale_seconds_widens_online_window():
+    now = time()
+    conn = _HealthConn([_gw('gw-a')],
+                       {'gw-a': [{'cc_timestamp': now - 7200.0}]})
+    out = cogniac.CogniacEdgeFlow.get_all_health(conn, stale_seconds=3 * 3600)
+    assert out[0]['online'] is True
+
+
+def test_get_all_health_empty_tenant():
+    conn = _HealthConn([], {})
+    assert cogniac.CogniacEdgeFlow.get_all_health(conn) == []
+
+
+def test_get_all_health_falls_back_to_gw_timestamp():
+    # A record lacking cc_timestamp (and the timestamp alias) must still yield
+    # a last_seen from the device clock rather than null.
+    now = time()
+    conn = _HealthConn([_gw('gw-a')],
+                       {'gw-a': [{'subsystem': 'gpus', 'gw_timestamp': now - 10.0}]})
+    out = cogniac.CogniacEdgeFlow.get_all_health(conn)
+    assert out[0]['last_seen'] == pytest.approx(now - 10.0)
+    assert out[0]['online'] is True
+
+
+def test_instance_health_reads_fields_from_gateway_object():
+    now = time()
+    conn = _HealthConn([], {'gw-placeholder': [{'cc_timestamp': now - 5.0}]})
+    ef = object.__new__(cogniac.CogniacEdgeFlow)
+    object.__setattr__(ef, '_edgeflow_keys', [])
+    object.__setattr__(ef, 'gateway_id', 'gw-placeholder')
+    object.__setattr__(ef, 'name', 'ef-placeholder')
+    object.__setattr__(ef, 'deployment_group_id', 'dg-0001')
+    object.__setattr__(ef, '_cc', conn)
+
+    h = ef.health()
+    assert h == {
+        'gateway_id': 'gw-placeholder',
+        'name': 'ef-placeholder',
+        'deployment_group_id': 'dg-0001',
+        'last_seen': h['last_seen'],
+        'online': True,
+        'current_workflow_id': None,  # not on this gateway record -> null
+    }
+    assert h['last_seen'] == pytest.approx(now - 5.0)
+
+
+# ---------------------------------------------------------------------------
+# CLI `edgeflows health` (#184)
+# ---------------------------------------------------------------------------
+
+
+def _run_health(monkeypatch, argv, conn):
+    from cogniac.cli import build_parser
+    import cogniac.cli as cli
+
+    monkeypatch.setattr(cli, "get_connection", lambda args=None: conn)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+def test_cli_edgeflow_health_emits_summary_array(monkeypatch, capsys):
+    now = time()
+    conn = _HealthConn(
+        [_gw('gw-a', deployment_group_id='dg-0001'), _gw('gw-b')],
+        {'gw-a': [{'cc_timestamp': now - 30.0}], 'gw-b': []},
+    )
+    _run_health(monkeypatch, ["edgeflow", "health"], conn)
+    out = json.loads(capsys.readouterr().out)
+    assert [r['gateway_id'] for r in out] == ['gw-a', 'gw-b']
+    a, b = out
+    assert a['online'] is True and a['deployment_group_id'] == 'dg-0001'
+    assert b['online'] is False and b['last_seen'] is None
+
+
+def test_cli_edgeflow_health_stale_minutes_flag(monkeypatch, capsys):
+    # 2h-old status: offline at the default 15 minutes, online at 240 minutes
+    now = time()
+    conn = _HealthConn([_gw('gw-a')], {'gw-a': [{'cc_timestamp': now - 7200.0}]})
+    _run_health(monkeypatch, ["edgeflow", "health"], conn)
+    assert json.loads(capsys.readouterr().out)[0]['online'] is False
+
+    conn = _HealthConn([_gw('gw-a')], {'gw-a': [{'cc_timestamp': now - 7200.0}]})
+    _run_health(monkeypatch, ["edgeflow", "health", "--stale-minutes", "240"], conn)
+    assert json.loads(capsys.readouterr().out)[0]['online'] is True

--- a/tests/test_edgeflows.py
+++ b/tests/test_edgeflows.py
@@ -477,13 +477,25 @@ def test_status_aliases_missing_timestamp_to_gw_timestamp():
 # ---------------------------------------------------------------------------
 
 
+class _FakeTenant:
+    tenant_id = 'tenant-placeholder'
+
+
 class _HealthConn:
     """Fake connection serving the tenant gateway list and one status
     envelope per gateway (latest record only, as the API returns for
-    reverse=True&limit=1)."""
+    reverse=True&limit=1). A per-gateway value that is an Exception is raised
+    from that device's status GET.
+
+    Exposes the tenant id only via the `tenant` property path
+    (connection.tenant.tenant_id), like the real CogniacConnection whose
+    `tenant` property raises the helpful "must specify tenant" error on a
+    tenant-less connection — get_all_health must use that path, matching
+    get_all, not the raw connection.tenant_id attribute."""
+
+    tenant = _FakeTenant()
 
     def __init__(self, gateways, status_by_gateway):
-        self.tenant_id = 'tenant-placeholder'
         self._gateways = gateways
         self._status = status_by_gateway
         self.status_urls = []
@@ -495,6 +507,8 @@ class _HealthConn:
         assert m, "unexpected url %s" % url
         self.status_urls.append(url)
         records = self._status.get(m.group(1), [])
+        if isinstance(records, Exception):
+            raise records
         return _FakeResp({'data': records[:1], 'paging': {'next': None}})
 
 
@@ -560,6 +574,43 @@ def test_get_all_health_stale_seconds_widens_online_window():
 def test_get_all_health_empty_tenant():
     conn = _HealthConn([], {})
     assert cogniac.CogniacEdgeFlow.get_all_health(conn) == []
+
+
+def test_get_all_health_one_bad_device_degrades_not_aborts():
+    # A gateway deleted between the tenant list call and its status GET (404
+    # ClientError) must degrade only its own record — online None (tri-state
+    # "could not determine", not False "determined offline") with the failure
+    # in an `error` key — while every other device still reports normally.
+    from cogniac.common import ClientError
+
+    now = time()
+    gateways = [
+        _gw('gw-ok', current_workflow_id='wf-0001'),
+        _gw('gw-gone', deployment_group_id='dg-0002'),
+        _gw('gw-quiet'),
+    ]
+    status = {
+        'gw-ok': [{'subsystem': 'cpu', 'cc_timestamp': now - 30.0}],
+        'gw-gone': ClientError('gateway not found (404)', status_code=404),
+        'gw-quiet': [],
+    }
+    conn = _HealthConn(gateways, status)
+    out = cogniac.CogniacEdgeFlow.get_all_health(conn, stale_seconds=900)
+
+    # the sweep completed for every device, in order
+    assert [r['gateway_id'] for r in out] == ['gw-ok', 'gw-gone', 'gw-quiet']
+
+    degraded = out[1]
+    assert degraded['online'] is None
+    assert degraded['last_seen'] is None
+    assert '404' in degraded['error']
+    # gateway-record fields still populated on the degraded record
+    assert degraded['name'] == 'ef-gw-gone'
+    assert degraded['deployment_group_id'] == 'dg-0002'
+
+    # healthy devices are unaffected and carry no error key
+    assert out[0]['online'] is True and 'error' not in out[0]
+    assert out[2]['online'] is False and 'error' not in out[2]
 
 
 def test_get_all_health_falls_back_to_gw_timestamp():


### PR DESCRIPTION
Addresses the client-derivable part of #184 (`edgeflows list/get` return null `last_seen`/`connection_status`, making fleet health invisible from the CLI). Fully populating connectivity on the gateway record itself needs backend work, so #184 stays open — but the per-device status endpoint works today, and each status record carries `cc_timestamp` (cloud-receipt clock), so an effective health summary can be derived client-side.

## What's added

**CLI**

```
cogniac edgeflows health [--stale-minutes N]     # default 15
```

Emits one JSON record per EdgeFlow in the tenant:

```json
{"gateway_id": ..., "name": ..., "deployment_group_id": ..., "last_seen": <epoch|null>, "online": <bool>, "current_workflow_id": ...}
```

- `last_seen` is the `cc_timestamp` of the device's most recent status record (fetched with `reverse=True&limit=1`, one bounded GET per device, fetched concurrently on up to 8 threads); falls back to `timestamp`/`gw_timestamp` on records that lack it.
- `online` = `last_seen` within `--stale-minutes` of now.
- A device with zero status records reports `last_seen: null, online: false`.
- `--format table` supported via new `edgeflow_health` columns; `gateway health` etc. work via the existing synonym groups.

**SDK** (sync + async, per the repo's symmetry rule)

- `CogniacEdgeFlow.get_all_health(connection, stale_seconds=900, max_workers=8)` — tenant-level summary (what the CLI uses).
- `CogniacEdgeFlow.health(stale_seconds=900)` — one device.
- `AsyncCogniacEdgeFlow.get_all_health(...)` / `.health(...)` — async counterparts (`asyncio.gather` with a semaphore cap), sharing the same derivation helper.

## Honest caveat (in docstrings and --help)

This is a **client-side derivation from status records on the cloud-receipt clock, not a true device heartbeat**: a device uploading a backlog of status records can briefly look "online" while the backlog drains. The real fix for `list`/`get` nulls remains backend-side.

## Tests

Mocked connections only (no live API calls): online / stale / no-records cases, `cc_timestamp` preferred over `gw_timestamp` (with `gw_timestamp` fallback), empty tenant, per-device request boundedness (`limit=1&reverse=True`), the `--stale-minutes` flag, instance-method field passthrough, and async parity. The smoke-test pairing lists gain `health` / `get_all_health`. Full suite: **300 passed, 110 skipped** (skips are the live-credential tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)